### PR TITLE
Fix for #65

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathbrowser/template.vue
@@ -354,9 +354,9 @@
                 </div>
                 <div class="checkboxes-group">
                   <div class="pathbrowser-newwindow" v-if="newWindow !== undefined"
-                       @click="toggleNewWindow"
-                       @keyup.space="toggleNewWindow">
-                    <input type="checkbox" id="newWindow" :checked="newWindow"/>
+                       @click="$emit('toggle-newWindow')"
+                       @keyup.space="$emit('toggle-newWindow')">
+                    <input type="checkbox" id="newWindow" v-model="newWindow"/>
                     <label for="newWindow">Open in new window?</label>
                   </div>
                   <div class="pathbrowser-rel"
@@ -443,7 +443,10 @@ export default {
     currentPath: String,
     selectedPath: String,
     withLinkTab: Boolean,
-    newWindow: Boolean,
+    newWindow: {
+      type: Boolean,
+      default: false
+    },
     toggleNewWindow: Function,
     setCurrentPath: Function,
     setSelectedPath: Function,

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -47,7 +47,7 @@
         :browserType="browser.type"
         :withLinkTab="browser.withLinkTab"
         :newWindow="browser.newWindow"
-        :toggleNewWindow="toggleBrowserNewWindow"
+        @toggle-newWindow="toggleBrowserNewWindow"
         :linkTitle="browser.linkTitle"
         :setLinkTitle="setBrowserLinkTitle"
         :currentPath="browser.path.current"

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/pathbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/pathbrowser/template.vue
@@ -53,6 +53,10 @@
             :browserType="browserType"
             :currentPath="currentPath"
             :selectedPath="selectedPath"
+            :newWindow="newWindow"
+            @toggle-newWindow="toggleNewWindow"
+            :rel="rel"
+            @toggle-rel="toggleRel"
             :withLinkTab="withLinkTab"
             :setCurrentPath="setCurrentPath"
             :setSelectedPath="setSelectedPath"
@@ -82,6 +86,8 @@ import Icon from '../../admin/components/icon/template.vue'
                 browserRoot: '/assets',
                 browserType: PathBrowser.Type.ASSET,
                 currentPath: '/assets',
+                newWindow: false,
+                rel: false,
                 selectedPath: null,
                 withLinkTab: true,
                 editing: false
@@ -174,6 +180,12 @@ import Icon from '../../admin/components/icon/template.vue'
     },
     remove() {
       this.value = "";
+    },
+    toggleNewWindow() {
+      this.newWindow = !this.newWindow;
+    },
+    toggleRel() {
+      this.rel = !this.rel;
     }
   }
 }


### PR DESCRIPTION
Fixes [#65](https://github.com/swiss-taekwondo/stkd-theme/issues/65)

The `rel` and `target` do not work for images (because they're not meant to be set there) and also not for social icons.
In the RTE, it does set it correctly, because these are links.
We need to think about a Solution how to show it when necessary and when not. And if necessary, how to apply them correctly.

This PR only fixes [#65](https://github.com/swiss-taekwondo/stkd-theme/issues/65) and changes the `toggleNewWindow` to `$emit('toggle-newWindow')` for consistency.

New issue created ([#71](https://github.com/swiss-taekwondo/stkd-theme/issues/71))