### PR TITLE
Asset names fixes

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -733,12 +733,11 @@ export default {
       this.formmodel.title = this.node.title
     },
 
-    performRenameNode(newName, newTitle) {
+    performRenameNode(newName) {
       const vm = this;
       $perAdminApp.stateAction(`rename${this.uNodeType}`, {
         path: this.currentObject,
         name: newName,
-        title: newTitle,
         edit: this.isEdit
       }).then((data) => {
         if (vm.nodeType === 'asset' || vm.nodeType === 'object') {
@@ -758,6 +757,7 @@ export default {
         this.setActiveTab(Tab.INFO)
       })
     },
+
     openPublishingModal(){
       console.log("Open Publishing Modal")
       // this.$refs.publishingModal.open()
@@ -813,6 +813,7 @@ export default {
         });
       });
     },
+
     copyNode() {
       $perAdminApp.getApi().populateNodesForBrowser(this.path.current, 'pathBrowser')
           .then(() => {
@@ -893,6 +894,11 @@ export default {
           srcPath: this.currentObject,
           targetPath: this.path.selected,
           resourceType: this.node.resourceType,
+          mimeType: this.node.mimeType,
+        }).then(() => {
+          // dumb hack to make copy source render properly.
+          // Assets lose their resourceType and mimeType after being copied in explorer children array but it still exists
+          setTimeout(() => { $perAdminApp.getApi().populateNodesForBrowser(this.path.selected) }, 100);
         });
       }
       this.isCopyOpen = false;

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -456,6 +456,7 @@ export default {
       return $perAdminApp.findNodeFromPath(this.$root.$data.admin.nodes, this.currentObject);
     },
     node() {
+      console.log('computing node: ', this.nodeType, NodeType.OBJECT, this.rawCurrentObject, this.nodeFromPath)
       if (this.nodeType === NodeType.OBJECT) {
         return this.rawCurrentObject.data
       }
@@ -534,6 +535,10 @@ export default {
     },
     selfOrAnyDescendantActivated() {
       const node = this.node;
+      if (!node) {
+        console.warn('selfOrAnyDescendantActivated() failed')
+        return
+      }
       return node.activated || node.selfOrAnyDescendantActivated;
     },
     classForActionDisabledOnActivatedResource() {
@@ -700,11 +705,12 @@ export default {
       this.valid.state = isValid;
       this.valid.errors = errors;
     },
+
     onConfirmDialog (event) {
       if (event === 'confirm') {
         const isValid = this.$refs.renameForm.validate()
         if (isValid) {
-          this.performRenameNode(this.formmodel.name, this.formmodel.title)
+          this.performRenameNode(this.formmodel.name, this.formmodel.title || "")
         } else {
           return
         }
@@ -719,6 +725,7 @@ export default {
       this.formmodel.name = this.node.name
       this.formmodel.title = this.node.title
     },
+
     performRenameNode(newName, newTitle) {
       const vm = this;
       $perAdminApp.stateAction(`rename${this.uNodeType}`, {
@@ -767,6 +774,7 @@ export default {
       console.log("Close Publishing Modal")
       this.isPublishDialogOpen = false;
     },
+
     checkActivationStatusAndPerform(action) {
       if (this.selfOrAnyDescendantActivated) {
         $perAdminApp.toast("You cannot perform this operation yet. The resource or one of its children is still published." +
@@ -775,7 +783,11 @@ export default {
         action();
       }
     },
+
     renameNode() {
+      // initialize with existing values
+      if (this.formmodel && !this.formmodel.title) this.formmodel.title = this.node.title
+      if (this.formmodel && !this.formmodel.name) this.formmodel.name = this.node.name
       this.checkActivationStatusAndPerform(() => {
         this.$refs.renameModal.open();
         this.$nextTick(() => {
@@ -783,6 +795,7 @@ export default {
         })
       });
     },
+
     moveNode() {
       this.checkActivationStatusAndPerform(() => {
         $perAdminApp.getApi().populateNodesForBrowser(this.path.current, 'pathBrowser')
@@ -849,8 +862,12 @@ export default {
             }
           })
     },
+
+    // after copy dialog
     onCopySelect() {
-      if (this.node.resourceType === 'nt:file') {
+      // debugger
+      // not a file for some reason
+      if (this.node.resourceType === 'nt:file' || this.node.resourceType === 'per:Asset') {
         let to = this.path.selected
 
         if (!to) {
@@ -861,7 +878,8 @@ export default {
 
         $perAdminApp.stateAction('copyFile', {
           from: this.currentObject,
-          to
+          to,
+          resourceType: this.node.resourceType,
         });
       } else {
         $perAdminApp.stateAction('copyPage', {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -864,7 +864,7 @@ export default {
 
     // after copy dialog
     onCopySelect() {
-      // not a file for some reason
+      // Assets are not a nt:file, they are per:Asset. Using copyFile() on an asset gives it resouceType of nt:file and I could not seem to prevent that.
       if (this.node.resourceType === 'nt:file') {
         let to = this.path.selected
 

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -456,7 +456,6 @@ export default {
       return $perAdminApp.findNodeFromPath(this.$root.$data.admin.nodes, this.currentObject);
     },
     node() {
-      console.log('computing node: ', this.nodeType, NodeType.OBJECT, this.rawCurrentObject, this.nodeFromPath)
       if (this.nodeType === NodeType.OBJECT) {
         return this.rawCurrentObject.data
       }
@@ -865,9 +864,8 @@ export default {
 
     // after copy dialog
     onCopySelect() {
-      // debugger
       // not a file for some reason
-      if (this.node.resourceType === 'nt:file' || this.node.resourceType === 'per:Asset') {
+      if (this.node.resourceType === 'nt:file') {
         let to = this.path.selected
 
         if (!to) {
@@ -880,11 +878,13 @@ export default {
           from: this.currentObject,
           to,
           resourceType: this.node.resourceType,
+          mimeType: this.node.mimeType,
         });
       } else {
         $perAdminApp.stateAction('copyPage', {
           srcPath: this.currentObject,
           targetPath: this.path.selected,
+          resourceType: this.node.resourceType,
         });
       }
       this.isCopyOpen = false;

--- a/admin-base/ui.apps/src/main/js/api.js
+++ b/admin-base/ui.apps/src/main/js/api.js
@@ -159,8 +159,8 @@ class PerApi {
         return impl.movePage(path, to, type)
     }
 
-    copyPage(srcPath, targetPath, name=null) {
-        return impl.copyPage(srcPath, targetPath, name)
+    copyPage(srcPath, targetPath, name=null, otherProperties) {
+        return impl.copyPage(srcPath, targetPath, name, otherProperties)
     }
 
     deletePageNode(path, nodePath) {

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -790,11 +790,10 @@ class PerAdminImpl {
         .then(() => this.populateNodesForBrowser(path))
   }
 
-  renameAsset(path, newName, newTitle) {
+  renameAsset(path, newName) {
     return new Promise((resolve, reject) => {
       let data = new FormData()
       data.append('to', newName)
-      data.append('title', newTitle)
       updateWithForm('/admin/asset/rename.json' + path, data)
           .then((data) => this.populateNodesForBrowser(path))
           .then(() => resolve())
@@ -861,7 +860,7 @@ class PerAdminImpl {
     })
   }
 
-  copyPage(srcPath, targetPath, name = null) {
+  copyPage(srcPath, targetPath, name = null, otherProperties) {
     return new Promise((resolve, reject) => {
       let data = new FormData()
       data.append('path', srcPath)
@@ -870,6 +869,16 @@ class PerAdminImpl {
       data.append('newName', name)
       data.append('newTitle', name)
       data.append('type', 'child')
+
+      if (otherProperties) {
+        const keys = Object.keys(otherProperties)
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          const value = otherProperties[key]
+          data.append(key, value)
+        }
+      }
+
       updateWithForm('/admin/createPageFromSkeletonPage.json', data)
           .then((data) => this.populateNodesForBrowser(srcPath))
           .then(() => resolve())

--- a/admin-base/ui.apps/src/main/js/mixins/NodeNameValidation.js
+++ b/admin-base/ui.apps/src/main/js/mixins/NodeNameValidation.js
@@ -3,8 +3,8 @@ export default {
         return {
             formmodel: {
                 path: $perAdminApp.getNodeFromView('/state/tools/pages'),
+                // Using the rename modal to change the title is weird, since we are then forced to rename the file-name. Removing the title from here, since it can be updated in metadata.
                 name: '',
-                title: '',
                 templatePath: '',
                 skeletonPagePath: ''
             },
@@ -17,18 +17,6 @@ export default {
             nameChanged: false,
             nameSchema: {
                 fields: [
-                    {
-                        type: "input",
-                        inputType: "text",
-                        label: "Title",
-                        model: "title",
-                        required: true,
-                        onChanged: (model, newVal, oldVal, field) => {
-                          if(!this.nameChanged && this.uNodeType !== "Asset") {
-                              this.formmodel.name = $perAdminApp.normalizeString(newVal);
-                          }
-                        }
-                    },
                     {
                         type: "input",
                         inputType: "text",

--- a/admin-base/ui.apps/src/main/js/stateActions/copyFile.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/copyFile.js
@@ -4,15 +4,22 @@ import { SUFFIX_PARAM_SEPARATOR } from '../constants';
 
 let log = LoggerFactory.logger('copyFile').setLevelDebug();
 
-export default function(me, { from, to }) {
+export default function(me, { from, to, resourceType = 'nt:file' }) {
   log.fine({ from, to });
 
+  console.log('TESING: ', me, from, to, resourceType)
+  debugger
   const view = me.getView();
   const page = to.split('/')[3];
   const file = from.split('/').pop();
+  let filename = file;
+  let extension = "";
   const fileSplit = file.split('.');
-  const extension = fileSplit.pop();
-  let filename = `${fileSplit.join('.')}-copy.${extension}`;
+  if (fileSplit.length > 0) {
+    extension = "." + fileSplit.pop();
+  }
+  filename = `${fileSplit.join('.')}-copy${extension}`;
+
   const options = {
     headers: {
       'Content-Type': 'text/plain',
@@ -27,7 +34,7 @@ export default function(me, { from, to }) {
     let counter = 2;
 
     while (existingNode) {
-      filename = `${fileSplit.join('.')}-copy-${counter}.${extension}`;
+      filename = `${fileSplit.join('.')}-copy-${counter}${extension}`;
       existingNode = me.findNodeFromPath(
         me.getView().admin.nodes,
         `${to}/${filename}`
@@ -43,7 +50,7 @@ export default function(me, { from, to }) {
     })
     .then((response) => {
       set(view, '/state/tools/file', to);
-      set(view, '/state/tools/explorerpreview/resourceType', 'nt:file');
+      set(view, '/state/tools/explorerpreview/resourceType', resourceType);
 
       return response;
     })
@@ -55,6 +62,6 @@ export default function(me, { from, to }) {
     .then(() => ({
       path: `${to}/${filename}`,
       filename: filename,
-      resourceType: 'nt:file',
+      resourceType: resourceType,
     }));
 }

--- a/admin-base/ui.apps/src/main/js/stateActions/copyFile.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/copyFile.js
@@ -10,14 +10,9 @@ export default function(me, { from, to }) {
   const view = me.getView();
   const page = to.split('/')[3];
   const file = from.split('/').pop();
-  let filename = file;
-  let extension = "";
   const fileSplit = file.split('.');
-  if (fileSplit.length > 1) {
-    extension = "." + fileSplit.pop();
-  }
-  filename = `${fileSplit.join('.')}-copy${extension}`;
-
+  const extension = fileSplit.pop();
+  let filename = `${fileSplit.join('.')}-copy.${extension}`;
   const options = {
     headers: {
       'Content-Type': 'text/plain',
@@ -32,7 +27,7 @@ export default function(me, { from, to }) {
     let counter = 2;
 
     while (existingNode) {
-      filename = `${fileSplit.join('.')}-copy-${counter}${extension}`;
+      filename = `${fileSplit.join('.')}-copy-${counter}.${extension}`;
       existingNode = me.findNodeFromPath(
         me.getView().admin.nodes,
         `${to}/${filename}`

--- a/admin-base/ui.apps/src/main/js/stateActions/copyFile.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/copyFile.js
@@ -4,18 +4,16 @@ import { SUFFIX_PARAM_SEPARATOR } from '../constants';
 
 let log = LoggerFactory.logger('copyFile').setLevelDebug();
 
-export default function(me, { from, to, resourceType = 'nt:file' }) {
+export default function(me, { from, to }) {
   log.fine({ from, to });
 
-  console.log('TESING: ', me, from, to, resourceType)
-  debugger
   const view = me.getView();
   const page = to.split('/')[3];
   const file = from.split('/').pop();
   let filename = file;
   let extension = "";
   const fileSplit = file.split('.');
-  if (fileSplit.length > 0) {
+  if (fileSplit.length > 1) {
     extension = "." + fileSplit.pop();
   }
   filename = `${fileSplit.join('.')}-copy${extension}`;
@@ -50,7 +48,7 @@ export default function(me, { from, to, resourceType = 'nt:file' }) {
     })
     .then((response) => {
       set(view, '/state/tools/file', to);
-      set(view, '/state/tools/explorerpreview/resourceType', resourceType);
+      set(view, '/state/tools/explorerpreview/resourceType', 'nt:file');
 
       return response;
     })
@@ -62,6 +60,6 @@ export default function(me, { from, to, resourceType = 'nt:file' }) {
     .then(() => ({
       path: `${to}/${filename}`,
       filename: filename,
-      resourceType: resourceType,
+      resourceType: 'nt:file',
     }));
 }

--- a/admin-base/ui.apps/src/main/js/stateActions/copyPage.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/copyPage.js
@@ -29,9 +29,41 @@ let log = LoggerFactory.logger('copyPage').setLevelDebug();
 export default function(me, copy) {
   log.fine(copy);
   const api = me.getApi();
-  const { srcPath, targetPath, name } = copy;
+  let fileName = null;
+  const { srcPath, targetPath, name, resourceType } = copy;
 
-  api.copyPage(srcPath, targetPath, name).then(() => {
+  // change name for assets.
+  // Not really sure why this is used for assets, but copyFile() behaves wildly different and causes many unwanted sideeffects when copying assets.
+  if (resourceType === 'per:Asset') {
+    const file = srcPath.split('/').pop();
+    fileName = file;
+    let extension = "";
+    const fileSplit = file.split('.');
+    if (fileSplit.length > 1) {
+      extension = "." + fileSplit.pop();
+    }
+    fileName = `${fileSplit.join('.')}-copy${extension}`;
+
+    let existingNode = me.findNodeFromPath(
+      me.getView().admin.nodes,
+      `${targetPath}/${fileName}`
+    );
+
+    if (existingNode) {
+      let counter = 2;
+
+      while (existingNode) {
+        fileName = `${fileSplit.join('.')}-copy-${counter}${extension}`;
+        existingNode = me.findNodeFromPath(
+          me.getView().admin.nodes,
+          `${targetPath}/${fileName}`
+        );
+        counter++;
+      }
+    }
+  }
+
+  api.copyPage(srcPath, targetPath, name || fileName || null).then(() => {
     log.fine(`copy from ${srcPath} to ${targetPath} complete`);
   });
 }

--- a/admin-base/ui.apps/src/main/js/stateActions/copyPage.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/copyPage.js
@@ -30,7 +30,7 @@ export default function(me, copy) {
   log.fine(copy);
   const api = me.getApi();
   let fileName = null;
-  const { srcPath, targetPath, name, resourceType } = copy;
+  const { srcPath, targetPath, name, title, resourceType, mimeType } = copy;
 
   // change name for assets.
   // Not really sure why this is used for assets, but copyFile() behaves wildly different and causes many unwanted sideeffects when copying assets.
@@ -63,7 +63,7 @@ export default function(me, copy) {
     }
   }
 
-  api.copyPage(srcPath, targetPath, name || fileName || null).then(() => {
+  api.copyPage(srcPath, targetPath, name || fileName || null, {title, resourceType, mimeType}).then(() => {
     log.fine(`copy from ${srcPath} to ${targetPath} complete`);
   });
 }


### PR DESCRIPTION
Fixing asset names & titles during rename and copy.

- When finding duplicate file names while copying, number will be added before `.` as to preserve file extension.
- When renaming, leaving title empty will no longer result in null-string as title.
- When renaming input values will start with current name.

When copying assets, `copyPage` function is used. `copyFile` exists and has logic for handling file names with extensions already (fix was copied & altered from there) but it comes with many side-effects when using it to copy assets, so I altered `copyPage` instead.
