### PR TITLE
Links inside a Richtoolbar get download attribute if it's an asset

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathbrowser/template.vue
@@ -450,6 +450,7 @@ export default {
     toggleNewWindow: Function,
     setCurrentPath: Function,
     setSelectedPath: Function,
+    setResourceType: Function,
     linkTitle: String,
     setLinkTitle: Function,
     altText: String,
@@ -578,12 +579,13 @@ export default {
         'image/jpg',
         'image/gif',
         'timage/tiff',
-        'image/svg+xml'
+        'image/svg+xml',
+        'image/webp',
       ].indexOf(item.mimeType) >= 0
     },
     isImageExtension(item) {
       if (item.path) {
-        return item.path.match(/.(jpg|jpeg|png|gif|svg)$/i)
+        return item.path.match(/.(jpg|jpeg|png|gif|svg|webp)$/i)
       } else {
         return false
       }
@@ -604,7 +606,7 @@ export default {
       }
     },
     getFolderIcon(item) {
-      if (item && item.resourceType === 'per:Page') {
+      if (item) {
           return item.hasChildren ? 'folder_open' : 'description'
       }
       return this.isType(PathBrowser.Type.ASSET) ? 'folder_open' : 'description'
@@ -715,7 +717,7 @@ export default {
       if (this.isSelectable(item)) {
         this.previewType = 'selected'
         this.setSelectedPath(item.path)
-
+        this.setResourceType(item.resourceType)
       }
     },
     selectLink(ev) {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/groups/link/index.js
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/groups/link/index.js
@@ -1,6 +1,6 @@
 import insertLink from './insertLink'
-import editLink from './editLink'
-import removeLink from './removeLink'
+// import editLink from './editLink'
+// import removeLink from './removeLink'
 import {IconLib} from '../../../../../../../../js/constants'
 
 export default (vm) => {
@@ -15,13 +15,13 @@ export default (vm) => {
     ]
   }
 
-  if (vm.itemIsTag('A')) {
-    link.collapse = true
-    link.items = [
-        editLink(vm),
-        removeLink(vm)
-    ]
-  }
+  // if (vm.itemIsTag('A')) {
+  //   link.collapse = true
+  //   link.items = [
+  //       editLink(vm),
+  //       removeLink(vm)
+  //   ]
+  // }
 
   return link
 }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -24,7 +24,7 @@
           :items="group.items"
           :searchable="group.searchable"
           :class="group.class"
-          @toggle-click="group.toggleClick? group.toggleClick() : () => {}"
+          @toggle-click="group.toggleClick ? group.toggleClick() : () => {}"
           @click="exec($event.btn.cmd)"/>
     </template>
     <richtoolbar-group
@@ -54,6 +54,7 @@
         :setCurrentPath="setBrowserPathCurrent"
         :selectedPath="browser.path.selected"
         :setSelectedPath="setBrowserPathSelected"
+        :setResourceType="setBrowserResourceType"
         :rel="browser.rel"
         @toggle-rel="browser.rel = !browser.rel"
         :img-width="browser.img.width"
@@ -287,7 +288,7 @@ export default {
       this.browser.path.current = this.roots.pages
       this.browser.withLinkTab = true
       this.browser.newWindow = false
-      this.browser.type = PathBrowser.Type.PAGE
+      this.browser.type = PathBrowser.Type.FILE;
       this.saveSelection()
       this.selection.restore = true
       this.startBrowsing()
@@ -327,7 +328,6 @@ export default {
       this.browser.type = PathBrowser.Type.PAGE
       this.browser.newWindow = target === '_blank'
       this.browser.linkTitle = title
-      this.browser.path.suffix = '.html'
       this.saveSelection()
       this.selection.restore = true
       this.startBrowsing()
@@ -485,15 +485,22 @@ export default {
     // This runs after link is chosen in modal
     onLinkSelect(vm = this) {
       if (this.param.cmd === 'insertLink') {
-        if (this.browser.path.selected.startsWith('/')) {
+        if (this.browser.path.selected.startsWith('/') && this.browser.type === "Page") {
           this.browser.path.selected += '.html'
         }
 
         const link = this.selection.doc.createElement('a')
         link.setAttribute('href', this.browser.path.selected)
-        link.setAttribute('title', this.browser.linkTitle)
-        link.setAttribute('target', this.browser.newWindow ? '_blank' : '_self')
-        link.setAttribute('rel', this.browser.rel ? 'noopener noreferrer' : '')
+        if (this.browser.linkTitle) {
+          link.setAttribute('title', this.browser.linkTitle)
+        }
+        if (this.browser.type === ("Asset" || "file")) {
+          link.download = '';
+        } else {
+          link.setAttribute('target', this.browser.newWindow ? '_blank' : '_self')
+          link.setAttribute('rel', this.browser.rel ? 'noopener noreferrer' : '')
+        }
+        
         this.restoreSelection()
         this.$nextTick(() => {
           const range = this.getSelection(0)
@@ -597,6 +604,13 @@ export default {
     },
     setBrowserPathSelected(path) {
       this.browser.path.selected = path
+    },
+    setBrowserResourceType(type) {
+      if (!type) {
+        this.browser.type = PathBrowser.Type.FILE;
+      } else {
+        this.browser.type = type.split(":")[1];
+      }
     },
     toggleBrowserNewWindow() {
       this.browser.newWindow = !this.browser.newWindow

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -494,7 +494,7 @@ export default {
         if (this.browser.linkTitle) {
           link.setAttribute('title', this.browser.linkTitle)
         }
-        if (this.browser.type === ("Asset" || "file")) {
+        if (this.browser.type === "Asset" || this.browser.type === "file") {
           link.download = '';
         } else {
           link.setAttribute('target', this.browser.newWindow ? '_blank' : '_self')
@@ -503,7 +503,7 @@ export default {
         
         this.restoreSelection()
         this.$nextTick(() => {
-          const range = this.getSelection(0)
+          const range = document.getSelection().getRangeAt(0);
           const textEditor = this.$refs.richToolbar.nextElementSibling
 
           // check for list elements if start & end are not in same node.

--- a/pagerenderer/vue/ui.apps/src/main/js/state.js
+++ b/pagerenderer/vue/ui.apps/src/main/js/state.js
@@ -55,10 +55,12 @@ window.onclick = function(ev) {
 
     if(node) {
         var toUrl = node.href
+        // check if the link has the attribute 'download'
+        const isDownload = node.hasAttribute('download');
         log.fine("onClick() - "+ toUrl);
         log.fine(toUrl, currentServer)
 
-        if(!(
+        if(isDownload || !(
             toUrl.startsWith('http') ||
             toUrl.startsWith('/') ||
             toUrl.startsWith('#')

--- a/pagerenderer/vue/ui.apps/src/main/js/util.js
+++ b/pagerenderer/vue/ui.apps/src/main/js/util.js
@@ -42,15 +42,20 @@ export function pathToPathInfo(path) {
 export function pagePathToDataPath(path) {
 
     log.fine('converting',path,'to dataPath')
-    var firstHtmlExt = path.indexOf('.html')
-    var res = null
-    if(firstHtmlExt >= 0) {
-        var pathNoExt = path.substring(0,firstHtmlExt)
-        res = pathNoExt + DATA_EXTENSION
-    }
-    else {
-        res = path + DATA_EXTENSION
-    }
+    let res = null
+    const hasExtension = /\.[^\/\\]+$/.test(path);
+    if (hasExtension) {
+      if (path.endsWith('.html')) {
+        // .html found replace with DATA_EXTENSION
+        res = path.slice(0, -5) + DATA_EXTENSION;
+      } else {
+        // has another extension, don't modify
+        res = path;
+      }
+    } else {
+      // no extension found, add DATA_EXTENSION
+      res = path + DATA_EXTENSION;
+  }
     log.fine('result',res)
     return res
 


### PR DESCRIPTION
To test it locally do the following:

- run `cd ./pagerenderer/vue/ui.apps && npm run build`
- copy `./pagerenderer/vue/ui.apps/target/classes/etc/felibs/pagerendervue/js/perview.js` to [Local Peregrine](http://localhost:8080/bin/browser.html/etc/felibs/pagerendervue/js/perview.js)
- run `npm run watch` in the root

This fixes [#79](https://github.com/swiss-taekwondo/stkd-theme/issues/79).
It does not work perfectly fine yet, but it should work within bullet lists.
For "normal Text" it does not work to link multiple documents inside the same RTE.