### PR TITLE
Fix for Cards

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/workspace/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/workspace/template.vue
@@ -161,7 +161,8 @@ export default {
 
       const originalData = view.state.editor ? view.state.editor.originalData : null
       const currentNode = originalData ? $perAdminApp.findNodeFromPath(view.pageView.page, editorPath) : null
-      if (!originalData || !currentNode || JSON.stringify(originalData) === JSON.stringify(currentNode)) {
+      const replacer = (k, v) => k === '_opDeleteProps' ? undefined : v
+      if (!originalData || !currentNode || JSON.stringify(originalData, replacer) === JSON.stringify(currentNode, replacer)) {
         return this.openEditor(target)
       }
 

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/workspace/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/workspace/template.vue
@@ -11,9 +11,9 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-  
+
   http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -150,19 +150,27 @@ export default {
     showComponentEdit(me, target) {
       const view = $perAdminApp.getView()
       const editorPath = view.state.editor ? view.state.editor.path : null
-      
+
       if (editorPath && editorPath === target) {
         return this.openEditor(target)
       }
-      
+
       if (!editorPath) {
         return this.openEditor(target)
       }
 
       const originalData = view.state.editor ? view.state.editor.originalData : null
       const currentNode = originalData ? $perAdminApp.findNodeFromPath(view.pageView.page, editorPath) : null
-      const replacer = (k, v) => k === '_opDeleteProps' ? undefined : v
-      if (!originalData || !currentNode || JSON.stringify(originalData, replacer) === JSON.stringify(currentNode, replacer)) {
+      const replacer = (k, v) => k === '_opDeleteProps' || k === 'children' || v === null || v === '' ? undefined : v
+      const originalStr = JSON.stringify(originalData, replacer)
+      const currentStr = JSON.stringify(currentNode, replacer)
+      if (originalStr !== currentStr) {
+          let diffIdx = -1
+          for (let i = 0; i < Math.max(originalStr.length, currentStr.length); i++) {
+            if (originalStr[i] !== currentStr[i]) { diffIdx = i; break; }
+          }
+        }
+      if (!originalData || !currentNode || originalStr === currentStr) {
         return this.openEditor(target)
       }
 
@@ -198,7 +206,7 @@ export default {
         })
       })
     },
-    
+
     openEditor(target) {
       return $perAdminApp.stateAction('editComponent', target).then(() => {
         set($perAdminApp.getView(), `/state/editorVisible`, true)

--- a/admin-base/ui.apps/src/main/js/stateActions/editComponent.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/editComponent.js
@@ -11,9 +11,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -38,8 +38,9 @@ function bringUpEditor(me, view, target) {
         if (!view.state.editor || !view.state.editor.originalData) return;
         const currentNode = me.findNodeFromPath(view.pageView.page, view.state.editor.path)
         if (!currentNode) return;
-        const originalStr = JSON.stringify(view.state.editor.originalData)
-        const currentStr = JSON.stringify(currentNode)
+        const replacer = (k, v) => k === '_opDeleteProps' || k === 'children' || v === null || v === '' ? undefined : v
+        const originalStr = JSON.stringify(view.state.editor.originalData, replacer)
+        const currentStr = JSON.stringify(currentNode, replacer)
         if (originalStr !== currentStr) {
             e.preventDefault();
             e.returnValue = '';
@@ -59,8 +60,8 @@ function bringUpEditor(me, view, target) {
         if (!currentNode) {
             return true;
         }
-        const originalStr = JSON.stringify(view.state.editor.originalData, (k, v) => k === '_opDeleteProps' ? undefined : v)
-        const currentStr = JSON.stringify(currentNode, (k, v) => k === '_opDeleteProps' ? undefined : v)
+        const originalStr = JSON.stringify(view.state.editor.originalData, (k, v) => k === '_opDeleteProps' || k === 'children' || v === null || v === '' ? undefined : v)
+        const currentStr = JSON.stringify(currentNode, (k, v) => k === '_opDeleteProps' || k === 'children' || v === null || v === '' ? undefined : v)
         if (originalStr === currentStr) {
             return true;
         }
@@ -113,11 +114,11 @@ function bringUpEditor(me, view, target) {
 export default function(me, target) {
     log.fine(target)
     let view = me.getView()
-    
+
     if (view.state.editor && view.state.editor.path === target) {
         return Promise.resolve()
     }
-    
+
     return new Promise((resolve, reject) => {
         bringUpEditor(me, view, target).then(() => { resolve() }).catch(() => reject())
     })

--- a/admin-base/ui.apps/src/main/js/stateActions/editComponent.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/editComponent.js
@@ -59,8 +59,8 @@ function bringUpEditor(me, view, target) {
         if (!currentNode) {
             return true;
         }
-        const originalStr = JSON.stringify(view.state.editor.originalData)
-        const currentStr = JSON.stringify(currentNode)
+        const originalStr = JSON.stringify(view.state.editor.originalData, (k, v) => k === '_opDeleteProps' ? undefined : v)
+        const currentStr = JSON.stringify(currentNode, (k, v) => k === '_opDeleteProps' ? undefined : v)
         if (originalStr === currentStr) {
             return true;
         }


### PR DESCRIPTION
vue-form-generator adds `_opDeleteProps` to the live node when a radio field has no stored value. This has mutated the node after `originalData` was snapshotted, causing the unsaved changes comparison to always return "different" even with no user edits.

This happened for example in the cards on [Footer Template](http://localhost:8080/content/admin/pages/templates/edit.html/path:/content/stkd/templates/footer)