### PR TITLE
Changed the Navigation to a Priority Nav

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/AdminPaths.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/AdminPaths.java
@@ -48,5 +48,4 @@ public interface AdminPaths {
     String RESOURCE_TYPE_TENANT_SETUP_REPLICATION = API_PREFIX + "tenantSetupReplication";
     String RESOURCE_TYPE_IS_TENANT_NAME_AVAILABLE = API_PREFIX + "tenants/name/available";
     String RESOURCE_TYPE_IS_REFERENCED_IN_PUBLISH = API_PREFIX + "isReferencedInPublish";
-    String RESOURCE_TYPE_IS_COMPONENT_USED_IN_SKELETON = API_PREFIX + "isComponentUsedInSkeleton";
 }

--- a/admin-base/materialize/custom/_navbar.scss
+++ b/admin-base/materialize/custom/_navbar.scss
@@ -10,7 +10,7 @@ nav {
 
   .nav-wrapper {
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
 
     a {
       display: block;
@@ -41,7 +41,6 @@ nav {
     .nav-left {
       display: flex;
       align-items: center;
-      margin-right: auto;
       padding-top: 3px;
 
       .current-tenant-name {
@@ -80,12 +79,21 @@ nav {
     .nav-center {
       display: flex;
       align-items: center;
+      flex-wrap: nowrap;
+      overflow: visible;
+    }
+
+    .nav-mobile {
+      display: flex;
+      flex-wrap: nowrap;
+      align-items: center;
+      max-height: none;
+      overflow: visible;
     }
 
     .nav-right {
       display: flex;
       align-items: center;
-      margin-left: auto;
 
       .icon-link {
         padding: 0 .5rem;
@@ -280,7 +288,8 @@ nav {
     }
 
     .nav-mobile {
-      max-height: 54px;
+      max-height: none;
+      white-space: nowrap;
 
       .tenant-select {
         min-width: 150px;

--- a/admin-base/materialize/materialize-src/sass/components/_navbar.scss
+++ b/admin-base/materialize/materialize-src/sass/components/_navbar.scss
@@ -67,9 +67,6 @@ nav {
     }
 
     @media #{$medium-and-down} {
-      left: 50%;
-      transform: translateX(-50%);
-
       &.left, &.right {
         padding: 0;
         transform: none;

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/nav/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/nav/template.vue
@@ -47,16 +47,24 @@
         </admin-components-materializedropdown>
       </div>
       <div class="nav-center">
-        <ul v-if="!hideTenants" class="hide-on-med-and-down nav-mobile">
+        <ul v-if="!hideTenants" class="nav-mobile">
           <admin-components-action
-              v-for="section in sections"
+              v-for="section in visibleSections"
               :key="`section-${section.name}`"
               tag="li"
               :model="getSectionModel(section)"
-              :class="{active: getActiveSection() === section.name, 'no-mobile': !section.mobile}"
+              :class="{active: getActiveSection() === section.name}"
               class="nav-link"/>
+          <li v-if="hiddenItems.length > 0" class="nav-link">
+            <admin-components-materializedropdown
+                :below-origin="true"
+                :gutter="2"
+                :items="navMoreDdItems">
+              <a><i class="material-icons">more_horiz</i></a>
+            </admin-components-materializedropdown>
+          </li>
         </ul>
-        <ul v-else class="hide-on-med-and-down nav-mobile">
+        <ul v-else class="nav-mobile">
           <admin-components-action
               tag="li"
               :model="getSectionModel({title: 'Home', name: 'index'})"
@@ -64,7 +72,7 @@
               class="nav-link"/>
         </ul>
       </div>
-      <ul class="nav-right hide-on-med-and-down nav-mobile">
+      <ul class="nav-right nav-mobile">
         <admin-components-materializemodal ref="languageModal">
           <template>
             <vue-multiselect
@@ -125,6 +133,15 @@
           </template>
         </admin-components-materializedropdown>
         <admin-components-materializedropdown
+            v-if="!responsive || hiddenItems.length === 0"
+            tag="li"
+            class="nav-link more-link"
+            :below-origin="true"
+            :gutter="2"
+            :items="moreDdItems">
+          <i class="material-icons">more_vert</i>
+        </admin-components-materializedropdown>
+        <admin-components-materializedropdown
             tag="li"
             class="nav-link more-link"
             :below-origin="true"
@@ -155,16 +172,41 @@ export default {
       state: $perAdminApp.getView().state,
       tenants: $perAdminApp.getView().admin.tenants || [],
       sections: [
-        {name: 'welcome', title: 'Dashboard', mobile: true},
-        {name: 'pages', title: 'Pages'},
-        {name: 'assets', title: 'Assets'},
-        {name: 'objects', title: 'Objects'},
-        {name: 'templates', title: 'Templates'},
+        {name: 'welcome', title: 'Dashboard', priority: 10},
+        {name: 'pages', title: 'Pages', priority: 20},
+        {name: 'assets', title: 'Assets', priority: 30},
+        {name: 'objects', title: 'Objects', priority: 40},
+        {name: 'templates', title: 'Templates', priority: 50},
       ],
-      helpSelection: 'Help'
+      helpSelection: 'Help',
+      responsive: false,
+      windowWidth: window.innerWidth
     }
   },
   computed: {
+    visibleSections() {
+      if (!this.responsive || this.hideTenants) {
+        return this.sections
+      }
+      return this.sections.filter(s => !this.getHiddenNames().has(s.name))
+    },
+    hiddenItems() {
+      if (!this.responsive || this.hideTenants) {
+        return []
+      }
+      return this.sections.filter(s => this.getHiddenNames().has(s.name))
+    },
+    navMoreDdItems() {
+      return this.hiddenItems.map(s => {
+        const model = this.getSectionModel(s)
+        return {
+          label: model.title,
+          click: () => {
+            $perAdminApp.action(this, model.command, model.target)
+          }
+        }
+      })
+    },
     hideTenants() {
       return this.model.hideTenants ? true : $perAdminApp.getView().state.tenant ? false : true
     },
@@ -233,7 +275,34 @@ export default {
       this.refreshTenants()
     })
   },
+  mounted() {
+    this.checkResponsive()
+    window.addEventListener('resize', this.checkResponsive)
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.checkResponsive)
+  },
   methods: {
+    checkResponsive() {
+      this.responsive = window.innerWidth < 993
+      this.windowWidth = window.innerWidth
+    },
+    getHiddenNames() {
+      if (!this.responsive) return new Set()
+      const availableWidth = this.windowWidth - 380
+      const sectionWidth = 100
+      const hidden = new Set()
+      const sorted = [...this.sections].sort((a, b) => a.priority - b.priority)
+      let usedWidth = 0
+      for (const s of sorted) {
+        if (usedWidth + sectionWidth <= availableWidth) {
+          usedWidth += sectionWidth
+        } else {
+          hidden.add(s.name)
+        }
+      }
+      return hidden
+    },
     getSectionModel(section) {
       let target = `/content/admin/pages/${section.name}.html`
       if (this.state.tenant) {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/nav/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/nav/template.vue
@@ -133,15 +133,6 @@
           </template>
         </admin-components-materializedropdown>
         <admin-components-materializedropdown
-            v-if="!responsive || hiddenItems.length === 0"
-            tag="li"
-            class="nav-link more-link"
-            :below-origin="true"
-            :gutter="2"
-            :items="moreDdItems">
-          <i class="material-icons">more_vert</i>
-        </admin-components-materializedropdown>
-        <admin-components-materializedropdown
             tag="li"
             class="nav-link more-link"
             :below-origin="true"


### PR DESCRIPTION
This shows the Navigation also if the width is smaller than 992px. Before it was hidden.
So even on a Mobile, you can use the navigation.
In the end, this is needed as a first step for the [RTE Follow Up issue ](https://github.com/swiss-taekwondo/stkd-theme/issues/477) about the responsive-menu