### PR TITLE
don't show toast if no template path 

### DIFF
--- a/admin-base/ui.apps/package-lock.json
+++ b/admin-base/ui.apps/package-lock.json
@@ -2263,7 +2263,7 @@
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="
     },
     "debug": {
       "version": "3.2.6",

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/contentview/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/contentview/template.vue
@@ -461,6 +461,7 @@ export default {
           }
         }
         vm.unselect(vm)
+        if (!vm.target && !templatePath) return
         this.toast.templateComponent = $perAdminApp.toast(`
             <div>${vm.$i18n('fromTemplateNotifyMsg')}</div>
             ${templatePath ? `<div><a class="btn" style="white-space: nowrap;" href="/content/admin/pages/templates/edit.html/path:${templatePath}">modify</a></div>` : ''}

--- a/buildscripts/package-lock.json
+++ b/buildscripts/package-lock.json
@@ -1618,7 +1618,7 @@
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA=="
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "json-schema": {
       "version": "0.4.0",


### PR DESCRIPTION
Fixes: https://github.com/swiss-taekwondo/stkd-theme/issues/546

No longer showing "this component is from a template" toast when clicking the "page start" / "page end" elements within the topmost template. No toast is shown.