### PR TITLE
More rte fixes

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -1883,6 +1883,7 @@ export default {
         $perAdminApp.action(this, 'writeInlineToModel')
       }
 
+      textEditor.focus()
       this.$nextTick(() => {
         this.$nextTick(() => {
           const selectionAfter = ownerDoc.getSelection()

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -1482,8 +1482,30 @@ export default {
       const savedSel = isEditor ? (bufferedSel || liveSel) : (liveSel || bufferedSel)
       const preSelection = doc.defaultView?.getSelection?.() || null
       const preRange = preSelection && preSelection.rangeCount > 0 ? preSelection.getRangeAt(0).cloneRange() : null
+
+      if (preSelection && preRange && !preRange.collapsed) {
+        const startNode = preRange.startContainer
+        if (startNode.nodeType === Node.TEXT_NODE && preRange.startOffset === startNode.textContent.length) {
+          const walker = doc.createTreeWalker(container, NodeFilter.SHOW_ALL)
+          walker.currentNode = startNode
+          let nextNode = walker.nextNode()
+
+          while (nextNode && nextNode.nodeName === 'BR') {
+            nextNode = walker.nextNode()
+          }
+
+          if (nextNode) {
+            const adjustedRange = preRange.cloneRange()
+            adjustedRange.setStart(nextNode, 0)
+            preSelection.removeAllRanges()
+            preSelection.addRange(adjustedRange)
+          }
+        }
+      }
+
       const collapsedSidebarRange = isEditor && preRange && preRange.collapsed ? preRange : null
       const collapsedInlineRange = !isEditor && preRange && preRange.collapsed ? preRange : null
+
       if (isEditor && this._savedRange && doc.defaultView) {
         const selection = doc.defaultView.getSelection()
         if (selection) {
@@ -1797,11 +1819,6 @@ export default {
         setFontSizeOfEl(fontSizeParent, fontSize)
         fontSizeParent.style.fontSize = fontSize
         textEditor.dispatchEvent(new Event('input'))
-        if (textEditor.ownerDocument.querySelector('iframe#editview')) {
-          $perAdminApp.action(this, 'textEditorWriteToModel')
-        } else {
-          $perAdminApp.action(this, 'writeInlineToModel')
-        }
         return
       }
 
@@ -1821,11 +1838,7 @@ export default {
           span.style.fontSize = fontSize
           range.surroundContents(span)
           this.selectNodes([span])
-          if (textEditor.ownerDocument.querySelector('iframe#editview')) {
-            $perAdminApp.action(this, 'textEditorWriteToModel')
-          } else {
-            $perAdminApp.action(this, 'writeInlineToModel')
-          }
+          textEditor.dispatchEvent(new Event('input'))
         } else {
           setFontSizeOfEl(range.startContainer, fontSize)
         }
@@ -2539,7 +2552,7 @@ export default {
         }
 
         link.appendChild(range.extractContents())
-        if (link.textContent.trim().length < 1) {
+        if (link.textContent.trim().length < 1 && link.children.length === 0) {
           link.textContent = href
         }
         range.insertNode(link)

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -216,6 +216,7 @@ export default {
 
   data() {
     return {
+      defaultFontSize: null,
       openGroups: {},
       selection: {
         restore: false,
@@ -366,6 +367,7 @@ export default {
   },
 
   mounted() {
+    document.addEventListener('selectionchange', this.setDefaultFontSize)
     this.$nextTick(() => {
       window.addEventListener('resize', this.scheduleDocElDimensionsUpdate)
       this.initResizeObserver()
@@ -485,6 +487,7 @@ export default {
 
   beforeDestroy() {
     window.removeEventListener('resize', this.scheduleDocElDimensionsUpdate)
+    document.removeEventListener('selectionchange', this.setDefaultFontSize)
     if (this._resizeObserver) {
       this._resizeObserver.disconnect()
       this._resizeObserver = null
@@ -582,6 +585,16 @@ export default {
   },
 
   methods: {
+    setDefaultFontSize() {
+      const inlineEditingComponent = document.querySelector('#editview')?.contentDocument?.querySelector('.inline-editing')
+      if (inlineEditingComponent) {
+        const fontSizeNr = parseInt(getComputedStyle(inlineEditingComponent).fontSize)
+        if (!isNaN(fontSizeNr)) {
+          this.defaultFontSize = fontSizeNr
+        }
+      }
+    },
+
     initResizeObserver() {
       if (typeof ResizeObserver === 'undefined' || !this.$el) return
 
@@ -887,6 +900,7 @@ export default {
       return h(RichtoolbarFontSize, {
         key,
         props: {
+          defaultFontSize: this.defaultFontSize,
           exec: this.exec,
           isRangeInEditor: this.isRangeInEditor,
           isNodeInEditor: this.isNodeInEditor,

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbarfontsize/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbarfontsize/template.vue
@@ -228,8 +228,6 @@ export default {
 
     onListSelect(sizePreset) {
       this.inputValue = sizePreset;
-      this.exec("restoreSelection");
-      this.applyFontSize();
       this.$nextTick(() => {
         this.$refs.inputRef.parentElement.blur();
         this.$refs.inputRef.blur();
@@ -254,10 +252,9 @@ export default {
         selection.removeAllRanges();
         selection.addRange(this.selectionRange);
       }
-      const presetSelectionActive = this.isPresetSelectionActive()
-      if (presetSelectionActive) {
-        return
-      }
+      this.$nextTick(() => {
+        this.applyFontSize();
+      });
     },
     onFocusIn(e) {
       this.focused = true

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbarfontsize/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbarfontsize/template.vue
@@ -39,6 +39,10 @@ export default {
   name: "FontSizeSelector",
   components: { Icon },
   props: {
+    defaultFontSize: {
+      type: Number,
+      default: null,
+    },
     exec: { type: Function },
     iconLib: {
       type: String,
@@ -159,18 +163,9 @@ export default {
           this.inputValue = inlineFontSize
           return
         }
-
-        const computedFontSize = parseInt(check?.ownerDocument?.defaultView?.getComputedStyle(check).fontSize)
-        if (!isNaN(computedFontSize) && computedFontSize > 0) {
-          this.inputValue = computedFontSize
-          return
-        }
       }
 
-      const defaultFontSize = parseInt(this.getDefaultFontSize())
-      if (defaultFontSize && !isNaN(defaultFontSize)) {
-        this.inputValue = defaultFontSize
-      }
+      if (this.defaultFontSize) this.inputValue = this.defaultFontSize
     },
 
     // sets fontsize of input to that of selected text

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
@@ -227,9 +227,11 @@ export default {
         window.dispatchEvent(new CustomEvent('inline-richtoolbar:cmd', { detail: { cmd: 'underline' } }))
       } else if (key === Key.Z && ctrlOrCmd) {
         event.preventDefault()
+        event.stopPropagation()
         window.dispatchEvent(new CustomEvent('inline-richtoolbar:cmd', { detail: { cmd: 'undo' } }))
       } else if (key === Key.Y && ctrlOrCmd) {
         event.preventDefault()
+        event.stopPropagation()
         window.dispatchEvent(new CustomEvent('inline-richtoolbar:cmd', { detail: { cmd: 'redo' } }))
     }
     },

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
@@ -211,18 +211,22 @@ export default {
           this.$nextTick(() => this.pingToolbar())
         }
       } else if (key === Key.B && ctrlOrCmd) {
+        // override and dispatchevent here for more predictable outcomes and avoid contenteditable default keybinds when we have custom functionality.
         event.preventDefault()
-        document.execCommand('bold', false, null)
-        this.$nextTick(() => this.pingToolbar())
+        window.dispatchEvent(new CustomEvent('inline-richtoolbar:cmd', { detail: { cmd: 'bold' } }))
       } else if (key === Key.I && ctrlOrCmd) {
         event.preventDefault()
-        document.execCommand('italic', false, null)
-        this.$nextTick(() => this.pingToolbar())
+        window.dispatchEvent(new CustomEvent('inline-richtoolbar:cmd', { detail: { cmd: 'italic' } }))
       } else if (key === Key.U && ctrlOrCmd) {
         event.preventDefault()
-        document.execCommand('underline', false, null)
-        this.$nextTick(() => this.pingToolbar())
-      }
+        window.dispatchEvent(new CustomEvent('inline-richtoolbar:cmd', { detail: { cmd: 'underline' } }))
+      } else if (key === Key.Z && ctrlOrCmd) {
+        event.preventDefault()
+        window.dispatchEvent(new CustomEvent('inline-richtoolbar:cmd', { detail: { cmd: 'undo' } }))
+      } else if (key === Key.Y && ctrlOrCmd) {
+        event.preventDefault()
+        window.dispatchEvent(new CustomEvent('inline-richtoolbar:cmd', { detail: { cmd: 'redo' } }))
+    }
     },
     onFocusOut() {
       const view = this.view

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
@@ -68,7 +68,7 @@ const allowedStylesMap = {
 const allowedStylesElementsMap = {
   IMG: true,
 }
-function removeUnwantedStyles(tempDiv) {
+function cleanupRteContent(tempDiv) {
   tempDiv.querySelectorAll('[style]').forEach((span) => {
     if (allowedStylesElementsMap[span.nodeName]) return;
     const propertiesToRemove = []
@@ -98,6 +98,11 @@ function removeUnwantedStyles(tempDiv) {
 
   tempDiv.querySelectorAll('[id]').forEach((el) => {
     el.removeAttribute('id')
+  })
+
+  // remove empty anchor tags, sometimes appearing when adding & removing lists
+  tempDiv.querySelectorAll('a:empty').forEach((el) => {
+    el.remove()
   })
 
   return tempDiv
@@ -327,7 +332,7 @@ export default {
     },
   },
   watch: {
-    value(newValue) {
+    value() {
       if (!this.value) return
       const textCheckDiv = document.createElement('div')
       textCheckDiv.innerHTML = this.value
@@ -335,7 +340,7 @@ export default {
       // make sure to treat this as empty but if images and lists are present, treat it as non-empty.
       // as a side effect, this requires text to exist before being able to set Headings, super/sub-script.
       if (!textCheckDiv.textContent.trim() && !textCheckDiv.querySelector('img, ul, ol')) this.value = '';
-      removeUnwantedStyles(textCheckDiv)
+      cleanupRteContent(textCheckDiv)
       this.value = textCheckDiv.innerHTML
     }
   }


### PR DESCRIPTION
Sidebar RTE undo/redo was not set to keybind, and was being handled by contenteditable native history, which isn't what we want and wasn't triggerable by cypress. Fixed that.

Re-added applyfontsize when unfocusing fontsize input so users can manually type a fontsize again. Fixes: https://github.com/swiss-taekwondo/stkd-theme/issues/625

List toggle selection fix to fix edgecase where list is applied to sibling elements of selection

Fixed link insertion ignoring children elements when checking for content, resulting in replacing only-child images with text.

Remove `a:empty` on input. This should be safe, `:empty` is treated like `innerHTML === ""`, so images are safe.