### PR TITLE
Support pre-publish webhook

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
@@ -103,17 +103,25 @@ public final class ReplicationServlet extends ReplicationServletBase {
     )
     @interface Configuration {
         @AttributeDefinition(
-                name = "Webhook URL",
-                description = "Webhook URL to call after replication",
+                name = "Pre-publish Webhook Map",
+                description = "Pre-publish Webhook Configuration. Format: tenant = Webhook URL to call before replication",
                 required = false
         )
-        String webhook() default "";
+        String[] pre_publish_webhook_map();
+
+        @AttributeDefinition(
+                name = "Post-publish Webhook Map",
+                description = "Post-publish Webhook Configuration. Format: tenant = Webhook URL to call after replication",
+                required = false
+        )
+        String[] post_publish_webhook_map();
     }
 
     public static final String DEACTIVATE = "deactivate";
     public static final String RESOURCES = "resources";
 
-    private String webhook;
+    private Map<String, String> prePublishWebhookMap;
+    private Map<String, String> postPublishWebhookMap;
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -134,13 +142,16 @@ public final class ReplicationServlet extends ReplicationServletBase {
             final Resource resource,
             final ResourceResolver resourceResolver
     ) throws IOException, ReplicationException, RepositoryException {
-        if (parseBoolean(request.getParameter(DEACTIVATE))) {
-            return performDeactivation(replication, resource);
-        }
-
         final boolean deep = parseBoolean(request.getParameter("deep"));
         final boolean draft = parseBoolean(request.getParameter("draft"));
         final boolean callback = parseBoolean(request.getParameter("callback"));
+
+        final String tenant = getTenantNameFromResource(resource);
+        final String resourceType = resource.getResourceType();
+
+        if (parseBoolean(request.getParameter(DEACTIVATE))) {
+            return performDeactivation(replication, resource, callback, tenant);
+        }
 
         final PerUtil.ResourceChecker tenantChecker = new ReplicationUtil.TenantOwnedResourceChecker(resource);
         List<Resource> toBeReplicated = listMissingResources(resource, tenantChecker, deep, new LinkedList<>());
@@ -174,15 +185,17 @@ public final class ReplicationServlet extends ReplicationServletBase {
                     }
                 });
 
-        String resourceType = resource.getResourceType();
+        // Trigger the Pre-publish Webhook before querying for drafts and checking out (Halts on failure)
+        if (callback) {
+            String prePublishWebhook = prePublishWebhookMap.get(tenant);
+            callWebhook(prePublishWebhook, toBeReplicatedPaths.toArray(new String[0]), "pre-publish", true);
+        }
 
         // per:Page OR per:Object -> republish all pages (except published above) with label "Draft" or "Published"
         if (draft && (resourceType.equals(PAGE_PRIMARY_TYPE) || resourceType.equals(OBJECT_PRIMARY_TYPE))) {
             Workspace workspace = resourceResolver.adaptTo(Session.class).getWorkspace();
             QueryManager queryManager = workspace.getQueryManager();
             VersionManager versionManager = workspace.getVersionManager();
-
-            String tenant = getTenantNameFromResource(resource);
 
             // Find all pages
             String pages = "/"+ CONTENT +"/"+ tenant +"/" + PAGES;
@@ -270,8 +283,10 @@ public final class ReplicationServlet extends ReplicationServletBase {
 
         List<Resource> replicateResponse = replication.replicate(toBeReplicated);
 
+        // Trigger the Post-publish Webhook
         if (callback) {
-            callWebhook(allReplicatedPaths.toArray(new String[0]));
+            String postPublishWebhook = postPublishWebhookMap.get(tenant);
+            callWebhook(postPublishWebhook, allReplicatedPaths.toArray(new String[0]), "post-publish", false);
         }
 
         return prepareResponse(resource, replicateResponse);
@@ -280,7 +295,9 @@ public final class ReplicationServlet extends ReplicationServletBase {
     @NotNull
     private Response performDeactivation(
             final Replication replication,
-            final Resource resource
+            final Resource resource,
+            final boolean callback,
+            final String tenant
     ) throws ReplicationException, IOException {
         final var replicatedStuff = replication.deactivate(resource);
         for (final Resource r : streamReplicableResources(replicatedStuff)
@@ -288,16 +305,26 @@ public final class ReplicationServlet extends ReplicationServletBase {
             resourceManagement.deleteVersionLabel(r, PerConstants.PUBLISHED_LABEL);
         }
 
-        callWebhook(new String[]{resource.getPath()});
+        if (callback) {
+            String postPublishWebhook = postPublishWebhookMap.get(tenant);
+            callWebhook(postPublishWebhook, new String[]{resource.getPath()}, "post-publish", false);
+        }
 
         return prepareResponse(resource, replicatedStuff);
     }
 
-    private void callWebhook(String[] paths) {
-        try {
-            if (!isEmpty(webhook) && paths.length > 0) {
-                logger.trace("Calling FS Replication Webhook: {}", webhook);
+    /**
+     * Unified method for dispatching webhooks, capable of handling varying severity of errors.
+     * @param webhook The target URL
+     * @param paths The list of paths to send in the payload
+     * @param webhookType String descriptor ("pre-publish" or "post-publish")
+     * @param failOnError If true, exceptions and non-200 responses will throw ReplicationExceptions and halt the process
+     */
+    private void callWebhook(String webhook, String[] paths, String webhookType, boolean failOnError) throws ReplicationException {
+        if (!isEmpty(webhook) && paths.length > 0) {
+            logger.trace("Calling FS Replication {} Webhook: {}", webhookType, webhook);
 
+            try {
                 ObjectMapper objectMapper = new ObjectMapper();
                 ObjectNode payload = objectMapper.createObjectNode();
 
@@ -316,13 +343,27 @@ public final class ReplicationServlet extends ReplicationServletBase {
                         .build();
 
                 HttpClient httpClient = HttpClient.newHttpClient();
-                HttpResponse<String> httpResponse = httpClient.send(webhookRequest, HttpResponse.BodyHandlers.ofString());;
+                HttpResponse<String> httpResponse = httpClient.send(webhookRequest, HttpResponse.BodyHandlers.ofString());
 
-                logger.trace("FS Replication Webhook Response: " + httpResponse.statusCode());
+                // Conditionally throw an exception if the response is not HTTP 200 OK
+                if (failOnError && httpResponse.statusCode() != 200) {
+                    throw new ReplicationException(httpResponse.body());
+                }
+
+                logger.trace("FS Replication {} Webhook Response: {}", webhookType, httpResponse.statusCode());
+            } catch (ReplicationException e) {
+                // Re-throw our explicit exception if we care about failures
+                if (failOnError) {
+                    throw e;
+                }
+                logger.error("FS Replication {} Webhook failed with: {}", webhookType, e.getMessage(), e);
+            } catch (Exception e) {
+                // Wrap and throw general exceptions if we care, otherwise log and proceed
+                if (failOnError) {
+                    throw new ReplicationException("FS Replication " + webhookType + " Webhook failed: " + e.getMessage(), e);
+                }
+                logger.error("FS Replication {} Webhook failed with: {}", webhookType, e.getMessage(), e);
             }
-        }
-        catch (Exception e) {
-            logger.error("FS Replication Webhook failed with: " + e.getMessage());
         }
     }
 
@@ -335,6 +376,22 @@ public final class ReplicationServlet extends ReplicationServletBase {
     void modified(ReplicationServlet.Configuration configuration) { setup(configuration); }
 
     private void setup(ReplicationServlet.Configuration configuration) {
-        webhook = configuration.webhook();
+        prePublishWebhookMap = new HashMap<>();
+        String[] prePublishWebhooks = configuration.pre_publish_webhook_map();
+        for (String webhook : prePublishWebhooks) {
+            String[] tokens = webhook.split("=");
+            if (tokens.length == 2 && isNotEmpty(tokens[0]) && isNotEmpty(tokens[1])) {
+                prePublishWebhookMap.put(tokens[0], tokens[1]);
+            }
+        }
+
+        postPublishWebhookMap = new HashMap<>();
+        String[] postPublishWebhooks = configuration.post_publish_webhook_map();
+        for (String webhook : postPublishWebhooks) {
+            String[] tokens = webhook.split("=");
+            if (tokens.length == 2 && isNotEmpty(tokens[0]) && isNotEmpty(tokens[1])) {
+                postPublishWebhookMap.put(tokens[0], tokens[1]);
+            }
+        }
     }
 }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
@@ -186,10 +186,8 @@ public final class ReplicationServlet extends ReplicationServletBase {
                 });
 
         // Trigger the Pre-publish Webhook before querying for drafts and checking out (Halts on failure)
-        if (callback) {
-            String prePublishWebhook = prePublishWebhookMap.get(tenant);
-            callWebhook(prePublishWebhook, toBeReplicatedPaths.toArray(new String[0]), "pre-publish", true);
-        }
+        String prePublishWebhook = prePublishWebhookMap.get(tenant);
+        callWebhook(prePublishWebhook, toBeReplicatedPaths.toArray(new String[0]), "pre-publish", true);
 
         // per:Page OR per:Object -> republish all pages (except published above) with label "Draft" or "Published"
         if (draft && (resourceType.equals(PAGE_PRIMARY_TYPE) || resourceType.equals(OBJECT_PRIMARY_TYPE))) {
@@ -345,24 +343,28 @@ public final class ReplicationServlet extends ReplicationServletBase {
                 HttpClient httpClient = HttpClient.newHttpClient();
                 HttpResponse<String> httpResponse = httpClient.send(webhookRequest, HttpResponse.BodyHandlers.ofString());
 
-                // Conditionally throw an exception if the response is not HTTP 200 OK
-                if (failOnError && httpResponse.statusCode() != 200) {
-                    throw new ReplicationException(httpResponse.body());
+                // If the response is not HTTP 200 OK, throw an exception to be caught and logged below
+                if (httpResponse.statusCode() != 200) {
+                    throw new ReplicationException("HTTP " + httpResponse.statusCode() + " - " + httpResponse.body());
                 }
 
                 logger.trace("FS Replication {} Webhook Response: {}", webhookType, httpResponse.statusCode());
             } catch (ReplicationException e) {
-                // Re-throw our explicit exception if we care about failures
+                // Always log the error
+                logger.error("FS Replication {} Webhook failed with: {}", webhookType, e.getMessage());
+
+                // Halt the process only if we care about failures
                 if (failOnError) {
                     throw e;
                 }
-                logger.error("FS Replication {} Webhook failed with: {}", webhookType, e.getMessage(), e);
             } catch (Exception e) {
-                // Wrap and throw general exceptions if we care, otherwise log and proceed
+                // Always log general exceptions
+                logger.error("FS Replication {} Webhook failed with: {}", webhookType, e.getMessage(), e);
+
+                // Wrap and throw general exceptions if we care about failures
                 if (failOnError) {
                     throw new ReplicationException("FS Replication " + webhookType + " Webhook failed: " + e.getMessage(), e);
                 }
-                logger.error("FS Replication {} Webhook failed with: {}", webhookType, e.getMessage(), e);
             }
         }
     }
@@ -379,7 +381,7 @@ public final class ReplicationServlet extends ReplicationServletBase {
         prePublishWebhookMap = new HashMap<>();
         String[] prePublishWebhooks = configuration.pre_publish_webhook_map();
         for (String webhook : prePublishWebhooks) {
-            String[] tokens = webhook.split("=");
+            String[] tokens = webhook.split("=", 2);
             if (tokens.length == 2 && isNotEmpty(tokens[0]) && isNotEmpty(tokens[1])) {
                 prePublishWebhookMap.put(tokens[0], tokens[1]);
             }
@@ -388,7 +390,7 @@ public final class ReplicationServlet extends ReplicationServletBase {
         postPublishWebhookMap = new HashMap<>();
         String[] postPublishWebhooks = configuration.post_publish_webhook_map();
         for (String webhook : postPublishWebhooks) {
-            String[] tokens = webhook.split("=");
+            String[] tokens = webhook.split("=", 2);
             if (tokens.length == 2 && isNotEmpty(tokens[0]) && isNotEmpty(tokens[1])) {
                 postPublishWebhookMap.put(tokens[0], tokens[1]);
             }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
@@ -341,7 +341,7 @@ public final class ReplicationServlet extends ReplicationServletBase {
                         .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                         .build();
 
-                HttpClient httpClient = HttpClient.newHttpClient();
+                HttpClient httpClient = getHttpClient();
                 HttpResponse<String> httpResponse = httpClient.send(webhookRequest, HttpResponse.BodyHandlers.ofString());
 
                 // If the response is not HTTP 200 OK, throw an exception to be caught and logged below
@@ -396,5 +396,10 @@ public final class ReplicationServlet extends ReplicationServletBase {
                 postPublishWebhookMap.put(tokens[0], tokens[1]);
             }
         }
+    }
+
+    // For test mocking only
+    protected HttpClient getHttpClient() {
+        return HttpClient.newHttpClient();
     }
 }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
@@ -185,9 +185,10 @@ public final class ReplicationServlet extends ReplicationServletBase {
                     }
                 });
 
-        // Trigger the Pre-publish Webhook before querying for drafts and checking out (Halts on failure)
+        // Trigger the pre-publish Webhook before querying for drafts and checking out for the first path (Halts on failure)
         String prePublishWebhook = prePublishWebhookMap.get(tenant);
-        callWebhook(prePublishWebhook, toBeReplicatedPaths.toArray(new String[0]), "pre-publish", true);
+        String[] prePublishPaths = toBeReplicatedPaths.isEmpty() ? new String[0] : new String[]{ toBeReplicatedPaths.get(0) };
+        callWebhook(prePublishWebhook, prePublishPaths, "pre-publish", true);
 
         // per:Page OR per:Object -> republish all pages (except published above) with label "Draft" or "Published"
         if (draft && (resourceType.equals(PAGE_PRIMARY_TYPE) || resourceType.equals(OBJECT_PRIMARY_TYPE))) {

--- a/admin-base/core/src/test/java/com/peregrine/admin/servlets/ReplicationServletTest.java
+++ b/admin-base/core/src/test/java/com/peregrine/admin/servlets/ReplicationServletTest.java
@@ -1,16 +1,50 @@
 package com.peregrine.admin.servlets;
 
 import com.peregrine.replication.Replication;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 
 import static com.peregrine.admin.servlets.ReplicationServlet.DEACTIVATE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class ReplicationServletTest extends ReplicationServletTestBase {
 
+    private HttpServer mockServer;
+    private int dynamicPort;
+
     public ReplicationServletTest() throws NoSuchFieldException, Replication.ReplicationException {
         super(new ReplicationServlet());
+    }
+
+    @Before
+    public void startMockServer() throws Exception {
+        // Pass '0' to let the OS assign any available port safely
+        mockServer = HttpServer.create(new InetSocketAddress(0), 0);
+
+        // Retrieve the port the OS actually gave us
+        dynamicPort = mockServer.getAddress().getPort();
+
+        mockServer.createContext("/api/webhook", exchange -> {
+            String response = "Success";
+            exchange.sendResponseHeaders(200, response.length());
+            exchange.getResponseBody().write(response.getBytes());
+            exchange.close();
+        });
+        mockServer.start();
+    }
+
+    @After
+    public void stopMockServer() {
+        // Ensure the server shuts down after tests run so mock port is released
+        if (mockServer != null) {
+            mockServer.stop(0);
+        }
     }
 
     @Test
@@ -21,6 +55,28 @@ public final class ReplicationServletTest extends ReplicationServletTestBase {
 
     @Test
     public void performActivation() throws IOException {
+        performReplicationResponseContains(jcrContent);
+    }
+
+    @Test
+    public void testReplicationWithWebhook() throws Exception {
+        ReplicationServlet replServlet = (ReplicationServlet) servlet;
+
+        // Mock the OSGi Configuration interface
+        ReplicationServlet.Configuration config = mock(ReplicationServlet.Configuration.class);
+
+        // Map the webhook to hit our local mock server.
+        // We include "test" and "themeclean" to cover standard SlingServletTest mock paths.
+        String webhook1 = "themeclean=http://localhost:" + dynamicPort + "/api/webhook";
+        String webhook2 = "test=http://localhost:" + dynamicPort + "/api/webhook";
+
+        when(config.pre_publish_webhook_map()).thenReturn(new String[]{ webhook1, webhook2 });
+        when(config.post_publish_webhook_map()).thenReturn(new String[0]);
+
+        // Manually trigger the OSGi lifecycle to parse the config and populate the maps
+        replServlet.activate(config);
+
+        // Execute the standard replication. The internal HttpClient will hit mock port and succeed.
         performReplicationResponseContains(jcrContent);
     }
 

--- a/admin-base/core/src/test/java/com/peregrine/admin/servlets/ReplicationServletTestBase.java
+++ b/admin-base/core/src/test/java/com/peregrine/admin/servlets/ReplicationServletTestBase.java
@@ -14,6 +14,7 @@ import org.junit.Assert;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 
 import static com.peregrine.commons.util.PerConstants.PATH;
 import static org.mockito.Matchers.any;
@@ -23,7 +24,7 @@ import static org.mockito.Mockito.when;
 
 public class ReplicationServletTestBase extends SlingServletTest {
 
-    private final ReplicationServletBase servlet;
+    protected final ReplicationServletBase servlet;
 
     private final AdminResourceHandler resourceManagement = mock(AdminResourceHandler.class);
     private final ReplicationsContainerWithDefault replications = mock(ReplicationsContainerWithDefault.class);
@@ -37,6 +38,14 @@ public class ReplicationServletTestBase extends SlingServletTest {
         this.servlet = servlet;
         setField("replications", replications);
         setField("resourceManagement", resourceManagement);
+
+        // Safeguard to prevent NPEs in tests that bypass the activate() lifecycle
+        try {
+            setField("prePublishWebhookMap", new HashMap<String, String>());
+            setField("postPublishWebhookMap", new HashMap<String, String>());
+        } catch (NoSuchFieldException e) {
+            // Ignore: Other servlets extending this base class won't have these fields
+        }
 
         when(replications.getOrDefault(anyString())).thenReturn(replication);
 

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -1739,14 +1739,36 @@ class PerAdminImpl {
           .then(() => resolve())
           .catch(error => {
             clearInterval(noticeFunction)
-            $perAdminApp.notifyUser('Errors',
-                `were encountered when ${deactivate ? 'un'
-                    : ''}publishing ${path}. Please check with your admin.`)
-            if (error.response && error.response.data
-                && error.response.data.message) {
-              reject(error.response.data.message)
+
+            let errorMessage = `Errors were encountered when ${deactivate ? 'un' : ''}publishing ${path}. Please check with your admin.`;
+
+            if (error.response && error.response.data) {
+              const data = error.response.data;
+
+              // Try to extract the specific webhook error from the Java stack trace
+              if (data.exception && Array.isArray(data.exception) && data.exception.length > 0) {
+                const firstLine = data.exception[0];
+                // Match "HTTP <status> - <json payload>"
+                const match = firstLine.match(/HTTP \d+ - (.*)/);
+
+                if (match && match[1]) {
+                  try {
+                    const parsedDetail = JSON.parse(match[1]);
+                    // Use the specific 'error' or 'message' from the webhook response
+                    errorMessage = parsedDetail.error || parsedDetail.message || errorMessage;
+                  } catch (e) {
+                    // If it's not valid JSON, just show the raw string
+                    errorMessage = match[1];
+                  }
+                }
+              } else if (data.message && data.message !== "Replication Failed") {
+                // Fallback to the generic message if it's not the useless default one
+                errorMessage = data.message;
+              }
             }
-            reject(error)
+
+            $perAdminApp.notifyUser('Error', errorMessage);
+            reject(errorMessage);
           })
     })
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:css:patch": "cd admin-base/materialize && npm run build:patch",
     "build:patch:all": "npm run build:patch && npm run build:css:patch",
     "watch": "npm run build:patch:all && node ./watcher.js",
-    "mvn:install": "mvn clean install -P autoInstallPackage"
+    "mvn:install": "mvn clean install -P autoInstallPackage",
+    "mvn:install:full": "CMS_DIR=$(pwd) && cd $CMS_DIR/admin-base/core && mvn clean install -P autoInstallBundle && cd $CMS_DIR/platform/base && mvn clean install -P autoInstallBundle && cd $CMS_DIR/admin-base/materialize && mvn clean install -P autoInstallPackage && cd $CMS_DIR/admin-base/ui.apps && mvn clean install -P autoInstallPackage && cd $CMS_DIR/pagerenderer/vue/ui.apps && mvn clean install -P autoInstallPackage"
   },
   "author": "headwire.com, Inc",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes https://github.com/swiss-taekwondo/stkd-theme/issues/271 (no publish on error)

This PR refactors the publish webhook to support pre-publish and post-publish tenant based webhooks. 
The pre-publish webhook can be tested with https://github.com/swiss-taekwondo/stkd-page-checker. 
To set it up, follow the README and set the `.env` variables to eg
```
ORIGIN="http://localhost:8080"
WEBHOOK_KEY="02ae84a9-a881-4631-8c64-fb7db88324dc"
```
and then go to http://localhost:8080/system/console/configMgr and search for `Peregrine: Replication Servlet` and add a pre-publish webhook 
```
stkd=http://192.168.1.17:8787/?key=02ae84a9-a881-4631-8c64-fb7db88324dc
```

<img width="1369" height="307" alt="Screenshot 2026-06-08 at 09 45 09" src="https://github.com/user-attachments/assets/4e24caed-a5b5-4f27-9b2d-0d16feb4e464" />

Then try to publish a page or news object this should work fine. Then introduce any errors in the stkd theme by throwing an error or renaming a component model or anything that would throw errors on a page try to publish the page with the error. It should be catched and the publication should be prevented:

<img width="958" height="217" alt="Screenshot 2026-06-08 at 09 33 33" src="https://github.com/user-attachments/assets/b7b3bba7-d3f5-4f58-be81-dcfe62ecd2c5" />
