### PR TITLE
Default alt text

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -176,9 +176,11 @@ public class NodesServlet extends AbstractBaseServlet {
                         String mimeType = props.get(JCR_MIME_TYPE, String.class);
                         String title = props.get(TITLE, String.class);
                         String description = props.get("description", String.class);
+                        String alt = props.get("alt", String.class);
                         json.writeAttribute(MIME_TYPE, mimeType);
                         json.writeAttribute(TITLE, title);
                         json.writeAttribute("description", description);
+                        json.writeAttribute("alt", alt);
 
                         Resource tags = child.getChild("jcr:content/tags");
                         List<Tag> answer = new ArrayList<Tag>();

--- a/admin-base/ui.apps/package-lock.json
+++ b/admin-base/ui.apps/package-lock.json
@@ -2263,7 +2263,7 @@
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
     },
     "debug": {
       "version": "3.2.6",

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/assetview/explorer_dialog.json
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/assetview/explorer_dialog.json
@@ -69,5 +69,12 @@
       "label": "Description",
       "rows": 10,
       "placeholder": "enter a description for this asset"
+  },
+  {
+      "type": "input",
+      "inputType": "text",
+      "model": "alt",
+      "label": "Alt Text",
+      "placeholder": "alternative text for the image"
   }
 ]}

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -338,18 +338,24 @@
 </template>
 
 <script>
-import {IconLib, MimeType, NodeType, SUFFIX_PARAM_SEPARATOR} from '../../../../../../js/constants'
-import {deepClone, get, set} from '../../../../../../js/utils'
-import NodeNameValidation from '../../../../../../js/mixins/NodeNameValidation'
-import ReferenceUtil from '../../../../../../js/mixins/ReferenceUtil'
-import Icon from '../icon/template.vue'
-import PathBrowser from '../pathbrowser/template.vue'
-import MaterializeModal from '../materializemodal/template.vue'
-import ConfirmDialog from '../confirmdialog/template.vue'
-import Action from '../action/template.vue'
-import ExplorerPreviewNavItem from '../explorerpreviewnavitem/template.vue'
-import IconEditPage from '../iconeditpage/template.vue'
-import LinearPreloader from '../linearpreloader/template.vue'
+import {
+	IconLib,
+	MimeType,
+	NodeType,
+	SUFFIX_PARAM_SEPARATOR,
+} from "../../../../../../js/constants";
+import NodeNameValidation from "../../../../../../js/mixins/NodeNameValidation";
+import ReferenceUtil from "../../../../../../js/mixins/ReferenceUtil";
+import { deepClone, get, set } from "../../../../../../js/utils";
+import { resolveMediaText } from "../../../js/mediaText";
+import Action from "../action/template.vue";
+import ConfirmDialog from "../confirmdialog/template.vue";
+import ExplorerPreviewNavItem from "../explorerpreviewnavitem/template.vue";
+import Icon from "../icon/template.vue";
+import IconEditPage from "../iconeditpage/template.vue";
+import LinearPreloader from "../linearpreloader/template.vue";
+import MaterializeModal from "../materializemodal/template.vue";
+import PathBrowser from "../pathbrowser/template.vue";
 
 const Tab = {
   INFO: 'info',
@@ -752,7 +758,7 @@ export default {
       this.valid.errors = errors;
     },
 
-    autoFillAltFromAsset(newVal, schemaKey) {
+    async autoFillAltFromAsset(newVal, schemaKey) {
       if (!newVal || typeof newVal !== 'string' || !newVal.startsWith('/content/')) return
       const schema = this.getSchema(SchemaKey.MODEL)
       if (!schema || !schema.fields) return
@@ -791,15 +797,12 @@ export default {
       }
       if (!altModelKey) return
       if (this.node[altModelKey]) return
-      const altPath = newVal + '/jcr:content/alt'
-      fetch('/admin/nodes.json' + altPath)
-        .then(resp => resp.json())
-        .then(data => {
-          if (data.alt && !this.node[altModelKey]) {
-            this.node[altModelKey] = data.alt
-          }
-        })
-        .catch(() => {})
+      const rootData = this.$root && this.$root.$data
+      const adminNodes = rootData && rootData.admin && rootData.admin.nodes
+      const text = await resolveMediaText(newVal, adminNodes)
+      if (text && !this.node[altModelKey]) {
+        this.node[altModelKey] = text
+      }
     },
 
     onConfirmDialog (event) {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -615,6 +615,11 @@ export default {
       if (this.stateToolsEdit) {
         this.onEdit()
       }
+      this.$nextTick(() => {
+        if (this.node && this.isImage && !this.node.alt && this.node.title) {
+          this.node.alt = this.node.title
+        }
+      })
     },
     stateToolsEdit(edit) {
       this.edit = edit
@@ -737,6 +742,7 @@ export default {
           newVal: newVal
         })
       }
+      this.autoFillAltFromAsset(newVal, schemaKey)
     },
     onValidated(isValid, errors) {
       if (this.edit) {
@@ -744,6 +750,56 @@ export default {
       }
       this.valid.state = isValid;
       this.valid.errors = errors;
+    },
+
+    autoFillAltFromAsset(newVal, schemaKey) {
+      if (!newVal || typeof newVal !== 'string' || !newVal.startsWith('/content/')) return
+      const schema = this.getSchema(SchemaKey.MODEL)
+      if (!schema || !schema.fields) return
+      const findField = (fields) => {
+        if (!fields) return null
+        for (const f of fields) {
+          if (f.model === schemaKey) return f
+          if (f.fields) {
+            const found = findField(f.fields)
+            if (found) return found
+          }
+        }
+        return null
+      }
+      const field = findField(schema.fields)
+      if (!field) return
+      let altModelKey = null
+      if (field.defaultAltFromAsset === true) {
+        altModelKey = schemaKey + 'Alt'
+        if (field.model !== altModelKey) {
+          const byDefaultFrom = (fields) => {
+            for (const f of fields) {
+              if (f.defaultFrom === schemaKey) return f
+              if (f.fields) {
+                const found = byDefaultFrom(f.fields)
+                if (found) return found
+              }
+            }
+            return null
+          }
+          const targetField = byDefaultFrom(schema.fields)
+          if (targetField) {
+            altModelKey = targetField.model
+          }
+        }
+      }
+      if (!altModelKey) return
+      if (this.node[altModelKey]) return
+      const altPath = newVal + '/jcr:content/alt'
+      fetch('/admin/nodes.json' + altPath)
+        .then(resp => resp.json())
+        .then(data => {
+          if (data.alt && !this.node[altModelKey]) {
+            this.node[altModelKey] = data.alt
+          }
+        })
+        .catch(() => {})
     },
 
     onConfirmDialog (event) {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/nodetreeitem/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/nodetreeitem/template.vue
@@ -37,7 +37,9 @@ export default {
     },
     computed: {
       vTitle() {
-        return this.item.title || this.item.name
+        const path = this.item && this.item.path ? this.item.path : ''
+        const fallbackName = path.split('/').pop() || ''
+        return this.item.title || this.item.name || fallbackName
       },
       expandIcon() {
         return this.isOpen ? 'keyboard_arrow_down' : 'keyboard_arrow_right'

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathbrowser/template.vue
@@ -339,7 +339,7 @@
                       :value="linkTitle"
                       @input="setLinkTitle"/>
                 </div>
-                <div v-if="isImageExtension({path: selectedPath}) && isAsset" class="img-group">
+                <div v-if="isImagePath(selectedPath) && isAsset" class="img-group">
                   <div class="form-group">
                     <label for="linkTitle">Image Width (px)</label>
                     <input
@@ -626,19 +626,12 @@ export default {
       return false
     },
     isImagePath,
-    isImageExtension(item) {
-      if (item.path) {
-        return item.path.match(/.(jpg|jpeg|png|gif|svg|webp)$/i)
-      } else {
-        return false
-      }
-    },
     getFileExt(item) {
       return item.name.split('.').pop()
     },
     getFileIcon(item) {
       const ext = this.getFileExt(item)
-      if (this.isImagePath(item)) {
+      if (this.isImagePath(item && item.path)) {
         return {icon: 'image', lib: IconLib.MATERIAL_ICONS}
       } else if (ext === 'xml') {
         return {icon: 'file-code', lib: IconLib.FONT_AWESOME}
@@ -773,7 +766,7 @@ export default {
     isSelectable(item) {
       if (!this.isBrowserTypeImage) {
         return true
-      } else if (this.isImagePath(item) || this.isImageExtension(item)) {
+      } else if (this.isImagePath(item && item.path)) {
         return true
       }
       return false
@@ -785,7 +778,7 @@ export default {
     onFileDropperUploadDone(files) {
       files.reverse().some((file) => {
         file.mimeType = file.type
-        if (this.isImagePath(file)) {
+        if (this.isImagePath(file.name)) {
           this.setSelectedPath(`${this.currentPath}/${file.name}`)
           return true
         }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathbrowser/template.vue
@@ -280,7 +280,7 @@
                       </div>
                       <template v-if="isFile(item)">
                         <img
-                            v-if="isImage(item)"
+                            v-if="isImagePath(item)"
                             :class="isSelected(item.path) ? 'item-image selected' : 'item-image'"
                             v-bind:style="`width: ${cardSize}px`"
                             v-bind:src="item.path"
@@ -414,7 +414,7 @@
                   <admin-components-iconopenfolder></admin-components-iconopenfolder>
                 </div>
                 <template v-else>
-                  <img v-if="isImage(preview)" class="preview-image" v-bind:src="preview.path" :alt="preview.name"/>
+                  <img v-if="isImagePath(preview)" class="preview-image" v-bind:src="preview.path" :alt="preview.name"/>
                   <icon v-bind="getFileIcon(preview)"/>
                 </template>
                 <dl class="preview-data">
@@ -462,8 +462,9 @@
 </template>
 
 <script>
-import {IconLib, PathBrowser} from '../../../../../../js/constants'
+import { IconLib, PathBrowser } from '../../../../../../js/constants'
 
+import {isImagePath} from '../../../js/mediaText'
 import FileDropper from '../filedropper/template.vue'
 import Icon from '../icon/template.vue'
 
@@ -624,17 +625,7 @@ export default {
     onPrevent() {
       return false
     },
-    isImage(item) {
-      return [
-        'image/png',
-        'image/jpeg',
-        'image/jpg',
-        'image/gif',
-        'timage/tiff',
-        'image/svg+xml',
-        'image/webp',
-      ].indexOf(item.mimeType) >= 0
-    },
+    isImagePath,
     isImageExtension(item) {
       if (item.path) {
         return item.path.match(/.(jpg|jpeg|png|gif|svg|webp)$/i)
@@ -647,7 +638,7 @@ export default {
     },
     getFileIcon(item) {
       const ext = this.getFileExt(item)
-      if (this.isImage(item)) {
+      if (this.isImagePath(item)) {
         return {icon: 'image', lib: IconLib.MATERIAL_ICONS}
       } else if (ext === 'xml') {
         return {icon: 'file-code', lib: IconLib.FONT_AWESOME}
@@ -782,7 +773,7 @@ export default {
     isSelectable(item) {
       if (!this.isBrowserTypeImage) {
         return true
-      } else if (this.isImage(item) || this.isImageExtension(item)) {
+      } else if (this.isImagePath(item) || this.isImageExtension(item)) {
         return true
       }
       return false
@@ -794,7 +785,7 @@ export default {
     onFileDropperUploadDone(files) {
       files.reverse().some((file) => {
         file.mimeType = file.type
-        if (this.isImage(file)) {
+        if (this.isImagePath(file)) {
           this.setSelectedPath(`${this.currentPath}/${file.name}`)
           return true
         }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -40,6 +40,7 @@ import {
 } from './groups'
 import {get, restoreSelection, saveSelection, saveDomRangeSelection, set} from '../../../../../../js/utils'
 import {IconLib, PathBrowser} from '../../../../../../js/constants'
+import {fallbackMediaText, resolveMediaText} from '../../../js/mediaText'
 import RichtoolbarFontSize from '../richtoolbarfontsize/template.vue'
 import RichtoolbarGroup from '../richtoolbargroup/template.vue'
 import Pathbrowser from '../pathbrowser/template.vue'
@@ -241,6 +242,9 @@ export default {
         newWindow: false,
         linkTitle: '',
         altText: undefined,
+        mediaSourcePath: '',
+        mediaSourceText: '',
+        mediaSourceFallback: '',
         path: {
           current: '',
           selected: null,
@@ -2309,9 +2313,17 @@ export default {
       this.startBrowsing()
     },
 
-    editImage(vm = this, target) {
+    async getDefaultMediaText(path = '') {
+      const rootData = this.$root && this.$root.$data
+      const adminNodes = rootData && rootData.admin && rootData.admin.nodes
+      return resolveMediaText(path, adminNodes)
+    },
+
+    async editImage(vm = this, target) {
       const title = target.getAttribute('title')
       const src = target.getAttribute('src')
+      const defaultText = title || target.getAttribute('alt') || await vm.getDefaultMediaText(src)
+      const fallbackText = fallbackMediaText(src)
       const srcArr = src.split('/')
       const img = {
         width: target.style.width ? parseInt(target.style.width) : null,
@@ -2327,7 +2339,10 @@ export default {
       vm.browser.withLinkTab = true
       vm.browser.newWindow = undefined
       vm.browser.type = PathBrowser.Type.ASSET
-      vm.browser.linkTitle = title
+      vm.browser.linkTitle = defaultText
+      vm.browser.mediaSourcePath = src
+      vm.browser.mediaSourceText = defaultText || ''
+      vm.browser.mediaSourceFallback = fallbackText
       vm.browser.element = target
       vm.browser.img.width = img.width
       vm.browser.img.height = img.height
@@ -2351,8 +2366,8 @@ export default {
       this.getEditorFrom(range).dispatchEvent(new Event('input'))
     },
 
-    editIcon(vm = this, target) {
-      const alt = target.getAttribute('alt') || ''
+    async editIcon(vm = this, target) {
+      const alt = target.getAttribute('alt') || await vm.getDefaultMediaText(target.getAttribute('src') || '')
       const src = target.getAttribute('src') || ''
       const img = {
         width: target.style.width ? parseInt(target.style.width) : 20,
@@ -2437,6 +2452,9 @@ export default {
       this.browser.open = false
       this.browser.withImageTab = false
       this.param.anchor = null
+      this.browser.mediaSourcePath = ''
+      this.browser.mediaSourceText = ''
+      this.browser.mediaSourceFallback = ''
       if (this.selection.restore) {
         this.restoreSelection()
         this.selection.restore = false
@@ -2455,7 +2473,7 @@ export default {
           this.onLinkSelect()
           return
         } else if (['insertImage', 'editImage', 'editIcon'].includes(this.param.cmd)) {
-          this.onImageSelect()
+          this.onImageSelect().catch((err) => console.error(err))
           return
         }
 
@@ -2595,14 +2613,14 @@ export default {
       }
     },
 
-    onImageSelect() {
+    async onImageSelect() {
       if (this.param.cmd === 'editIcon') {
         const imgEl = this.browser.element
         const styles = []
         if (this.browser.img.width) styles.push(`width: ${this.browser.img.width}px`)
         if (this.browser.img.height) styles.push(`height: ${this.browser.img.height}px`)
         if (this.browser.img.objectFit) styles.push(`object-fit: ${this.browser.img.objectFit}`)
-        imgEl.setAttribute('alt', this.browser.altText || '')
+        imgEl.setAttribute('alt', this.browser.altText || await this.getDefaultMediaText(this.browser.path.selected) || '')
         imgEl.setAttribute('style', styles.join(';'))
         const container = imgEl.closest('[data-per-inline]')
         if (container) $perAdminApp.action(this, 'writeElementToModel', container)
@@ -2613,14 +2631,14 @@ export default {
       }
       if (this.param.cmd === 'editImage') {
         const imgEl = this.browser.element
-        const linkTitle = this.browser.linkTitle
+        const linkTitle = this.browser.linkTitle || this.browser.altText || await this.getDefaultMediaText(this.browser.path.selected)
         const styles = []
         if (this.browser.img.width) styles.push(`width: ${this.browser.img.width}px`)
         if (this.browser.img.height) styles.push(`height: ${this.browser.img.height}px`)
         if (this.browser.img.objectFit) styles.push(`object-fit: ${this.browser.img.objectFit}`)
         imgEl.setAttribute('src', this.browser.path.selected)
-        imgEl.setAttribute('alt', linkTitle ? linkTitle : '')
-        imgEl.setAttribute('title', linkTitle ? linkTitle : '')
+        imgEl.setAttribute('alt', linkTitle || '')
+        imgEl.setAttribute('title', linkTitle || '')
         imgEl.setAttribute('style', styles.join(';'))
         if ($perAdminApp.getNodeFromViewOrNull('/state/contentview/editor/active')) {
           $perAdminApp.action(this, 'reWrapEditable')
@@ -2628,6 +2646,9 @@ export default {
         const editor = imgEl.closest('[contenteditable="true"]')
         if (editor) editor.dispatchEvent(new Event('input'))
         this.browser.element = null
+        this.browser.mediaSourcePath = ''
+        this.browser.mediaSourceText = ''
+        this.browser.mediaSourceFallback = ''
       } else {
         const doc = this.selection.doc || this.getInlineDoc() || document
         const win = doc.defaultView || window
@@ -2639,11 +2660,12 @@ export default {
           if (this.browser.img.width) styles.push(`width: ${this.browser.img.width}px`)
           if (this.browser.img.height) styles.push(`height: ${this.browser.img.height}px`)
           if (this.browser.img.objectFit) styles.push(`object-fit: ${this.browser.img.objectFit}`)
+          const mediaText = this.browser.linkTitle || this.browser.altText || await this.getDefaultMediaText(this.browser.path.selected)
 
           const img = doc.createElement('img')
           img.setAttribute('src', this.browser.path.selected)
-          img.setAttribute('alt', this.browser.linkTitle || '')
-          img.setAttribute('title', this.browser.linkTitle || '')
+          img.setAttribute('alt', mediaText || '')
+          img.setAttribute('title', mediaText || '')
           if (styles.length) {
             img.setAttribute('style', styles.join(';'))
           }
@@ -2659,12 +2681,10 @@ export default {
           if (editor) editor.dispatchEvent(new Event('input'))
         }
 
-        // This might be required for something else? But it causes empty RTE images to be overwritten with inline (empty) content when added in sidebar
-        // $perAdminApp.action(this, 'writeInlineToModel')
-        // this.$nextTick(() => {
-        //   $perAdminApp.action(this, 'textEditorWriteToModel')
-        // })
       }
+      this.browser.mediaSourcePath = ''
+      this.browser.mediaSourceText = ''
+      this.browser.mediaSourceFallback = ''
     },
 
     setBrowserPathCurrent(path) {
@@ -2673,6 +2693,12 @@ export default {
 
     setBrowserPathSelected(path) {
       this.browser.path.selected = path
+      if (this.param.cmd === 'editImage' && path && path !== this.browser.mediaSourcePath) {
+        const current = String(this.browser.linkTitle || '').trim()
+        if (!current || current === this.browser.mediaSourceText || current === this.browser.mediaSourceFallback) {
+          this.browser.linkTitle = ''
+        }
+      }
     },
 
     setBrowserResourceType(type) {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/subnav/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/subnav/template.vue
@@ -24,7 +24,7 @@
   -->
 <template>
     <div class="nav-content sub-nav" :class="classes">
-        <richtoolbar v-if="renderRichToolbar" class="on-sub-nav" :onSubNav="true"/>
+                <richtoolbar v-if="renderRichToolbar" class="on-sub-nav" :onSubNav="true"/>
         <div v-if="showNodeTree" class="page-tree">
             <admin-components-materializedropdown
                 ref="dropdown"
@@ -57,7 +57,7 @@ import {get} from '../../../../../../js/utils'
 import Richtoolbar from '../richtoolbar/template.vue'
 
 export default {
-    name: "Subnav",
+    name: 'admin-components-subnav',
     components: {Richtoolbar},
     props: ['model'],
     data() {
@@ -113,12 +113,15 @@ export default {
                 return []
             }
         },
-        currentNode() {
+      currentNode() {
           return $perAdminApp.findNodeFromPath(this.nodes, this.getPath())
               || {title: 'loading...'}
-        },
+      },
       vCurrentNodeTitle() {
-          return this.currentNode.title || this.currentNode.name
+          const currentNode = this.currentNode || {}
+          const currentPath = this.getPath() || currentNode.path || ''
+          const fallbackName = currentPath.split('/').pop() || ''
+          return currentNode.title || currentNode.name || fallbackName
       }
     },
     methods: {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/toolingpage/renderer.html
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/toolingpage/renderer.html
@@ -47,4 +47,6 @@
     Vue.component('datetime', window.VueDatetime.Datetime);
     Vue.directive('images-loaded', VueImagesLoaded)
     Vue.use(VueFormWizard)
+
+    $perAdminApp.loadComponent('admin-components-subnav')
 </script>

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/toolingpage/toolingpage.html
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/toolingpage/toolingpage.html
@@ -153,6 +153,7 @@
         $perAdminApp.loadComponent('admin-components-materializeswitch')
         $perAdminApp.loadComponent('admin-components-componentexplorer')
         $perAdminApp.loadComponent('admin-components-nodetreeitem')
+        $perAdminApp.loadComponent('admin-components-subnav')
         $perAdminApp.loadComponent('admin-components-publishingmodal')
         $perAdminApp.loadComponent('admin-components-translationsmodal')
         $perAdminApp.loadComponent('admin-components-publishinginfo')

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/pathbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/pathbrowser/template.vue
@@ -70,7 +70,7 @@
 
 <script>
 import {IconLib, PathBrowser} from '../../../../../js/constants'
-import {fallbackMediaText, normalizeAssetPath, resolveMediaText} from '../../js/mediaText'
+import {fallbackMediaText, isImagePath, normalizeAssetPath, resolveMediaText} from '../../js/mediaText'
 import {getBasePath} from '../../../../../js/mixins'
 
 import PathBrowserComponent from '../../admin/components/pathbrowser/template.vue'
@@ -123,9 +123,7 @@ export default {
           }
       },
       methods: {
-           isImagePath(path) {
-             return /\.(jpg|jpeg|png|gif|svg|webp)$/i.test(path || '')
-           },
+           isImagePath,
            getMediaTextTargets() {
              const modelName = String(this.schema && this.schema.model ? this.schema.model : '').toLowerCase()
              const targets = []

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/pathbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/pathbrowser/template.vue
@@ -45,7 +45,7 @@
           <icon v-bind="removeButtonIcon"/>
         </button>
       </div>
-        <img v-if="isImage(value)" :src="sanitizedValue" />
+        <img v-if="isImagePath(value)" :src="sanitizedValue" />
         <path-browser-component
             v-if="isOpen"
             :isOpen="isOpen"
@@ -70,13 +70,14 @@
 
 <script>
 import {IconLib, PathBrowser} from '../../../../../js/constants'
+import {fallbackMediaText, normalizeAssetPath, resolveMediaText} from '../../js/mediaText'
 import {getBasePath} from '../../../../../js/mixins'
 
 import PathBrowserComponent from '../../admin/components/pathbrowser/template.vue'
 import Icon from '../../admin/components/icon/template.vue'
 
 
-  export default {
+export default {
         props: ['model'],
         components: {Icon, PathBrowserComponent},
         mixins: [ VueFormGenerator.abstractField , getBasePath],
@@ -113,7 +114,80 @@ import Icon from '../../admin/components/icon/template.vue'
           this.browserRoot = this.getBasePath() + this.browserRoot
           this.currentPath = this.getBasePath() + this.currentPath
       },
+      mounted() {
+          this.syncMediaText(this.value)
+      },
+      watch: {
+          value(newValue) {
+              this.syncMediaText(newValue)
+          }
+      },
       methods: {
+           isImagePath(path) {
+             return /\.(jpg|jpeg|png|gif|svg|webp)$/i.test(path || '')
+           },
+           getMediaTextTargets() {
+             const modelName = String(this.schema && this.schema.model ? this.schema.model : '').toLowerCase()
+             const targets = []
+             const push = (name) => {
+               if (name && !targets.includes(name)) {
+                 targets.push(name)
+               }
+             }
+
+             if (/logo/.test(modelName)) push('logoalttext')
+             if (/icon/.test(modelName)) push('iconalttext')
+             if (/bgimage/.test(modelName) || /background.*image/.test(modelName)) push('bgimagealttext')
+             if (/imagepath$/.test(modelName) || /path$/.test(modelName)) push('alt')
+             if (/src$/.test(modelName)) push('mediatitle')
+             if (/image/.test(modelName)) {
+               push('imagealttext')
+               push('mediatitle')
+               push('alt')
+             }
+             if (/media/.test(modelName)) push('mediatitle')
+             push('altText')
+             push('alt')
+
+             return targets
+           },
+           getBlankMediaTextTarget() {
+             const targets = this.getMediaTextTargets()
+             return targets.find((name) => {
+               return String(this.model[name] || '').trim() === ''
+             }) || null
+           },
+           getMediaTextTargetsWithValues() {
+             return this.getMediaTextTargets().filter((name) => String(this.model[name] || '').trim() !== '')
+           },
+           async getDefaultMediaText(path = '') {
+             const rootData = this.$root && this.$root.$data
+             const adminNodes = rootData && rootData.admin && rootData.admin.nodes
+             return resolveMediaText(normalizeAssetPath(path), adminNodes)
+           },
+           async clearInheritedMediaText(path = this.value) {
+             const normalizedPath = normalizeAssetPath(path)
+             if (!normalizedPath) return
+             const defaultText = String(await this.getDefaultMediaText(normalizedPath) || '').trim()
+             const fallbackText = String(fallbackMediaText(normalizedPath) || '').trim()
+             if (!defaultText && !fallbackText) return
+             for (const targetField of this.getMediaTextTargetsWithValues()) {
+               const currentText = String(this.model[targetField] || '').trim()
+               if (currentText && (currentText === defaultText || currentText === fallbackText)) {
+                 this.$set(this.model, targetField, '')
+               }
+             }
+           },
+           async syncMediaText(path = this.selectedPath) {
+             const normalizedPath = normalizeAssetPath(path)
+             if (!normalizedPath) return
+             const targetField = this.getBlankMediaTextTarget()
+             if (!targetField) return
+             const text = await this.getDefaultMediaText(normalizedPath)
+             if (this.selectedPath && normalizedPath !== normalizeAssetPath(this.selectedPath)) return
+             if (String(this.model[targetField] || '').trim()) return
+             this.$set(this.model, targetField, text)
+           },
            onInputInput(event) {
              if (!this.editing) {
                this.value = event.target.value
@@ -122,8 +196,10 @@ import Icon from '../../admin/components/icon/template.vue'
             onCancel(){
                 this.isOpen = false
             },
-            onSelect() {
-                this.value = this.selectedPath
+            async onSelect() {
+                await this.clearInheritedMediaText(this.value)
+                this.value = normalizeAssetPath(this.selectedPath)
+                await this.syncMediaText(this.selectedPath)
                 this.$emit('select', this.selectedPath);
                 this.isOpen = false
             },
@@ -133,11 +209,10 @@ import Icon from '../../admin/components/icon/template.vue'
             setSelectedPath(path){
                 this.selectedPath = path
             },
-            isImage(path) {
-                return /\.(jpg|png|gif)$/.test(path);
-            },
             isValidPath(path, root){
-                return path && path !== root && path.includes(root)
+                const normalizedPath = normalizeAssetPath(path)
+                const normalizedRoot = normalizeAssetPath(root)
+                return normalizedPath && normalizedPath !== normalizedRoot && normalizedPath.includes(normalizedRoot)
             },
             browse() {
                 // root path is used to limit top lever directory of path browser
@@ -151,7 +226,7 @@ import Icon from '../../admin/components/icon/template.vue'
                 if(!type) {
                     root === `${this.getBasePath()}/pages` ? type = PathBrowser.Type.PAGE : type = PathBrowser.Type.ASSET
                 }
-                let selectedPath = this.value
+                let selectedPath = normalizeAssetPath(this.value)
                 // current path is the active directory in the path browser
                 let currentPath
                 // if a selected path is valid, currentPath becomes the selected path's parent
@@ -177,10 +252,11 @@ import Icon from '../../admin/components/icon/template.vue'
           }).catch((err) => {
         $perAdminApp.getApi().populateNodesForBrowser('/content', 'pathBrowser')
       })
-    },
-    remove() {
-      this.value = "";
-    },
+            },
+            async remove() {
+              await this.clearInheritedMediaText(this.value)
+              this.value = "";
+            },
     toggleNewWindow() {
       this.newWindow = !this.newWindow;
     },

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/js/mediaText.js
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/js/mediaText.js
@@ -1,0 +1,122 @@
+const mediaTextKeys = [
+  'alt',
+  'altText',
+  'title',
+  'headline',
+  'description',
+  'dc:title',
+  'dc:description',
+  'dam:title',
+  'dam:altText',
+  'dam:description',
+  'by-line_title',
+  'caption_abstract',
+  'image_description',
+  'jcr:title',
+  'jcr:description',
+]
+const mediaTextCache = new Map()
+
+function isPlaceholderMediaName(name = '') {
+  const fileName = String(name || '').trim()
+  if (!fileName) return true
+
+  const normalized = fileName.replace(/[-_]+/g, ' ').toLowerCase()
+  if (/^\d+$/.test(normalized)) return true
+  if (/^[0-9a-f]{32}$/i.test(fileName)) return true
+  if (/^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(fileName)) return true
+  if (/^(image|media|img|dcim)\s*\d+$/.test(normalized)) return true
+  if (/^(image|media|img|dcim)\s*[- ]\s*\d+$/.test(normalized)) return true
+  if (/^whatsapp image \d{4}(?:[- ]\d{2}){2} at \d{2}\.\d{2}\.\d{2}$/.test(normalized)) return true
+  if (/^\d+(?:_\d+){2,}(?:_[a-z])?$/i.test(fileName)) return true
+  return false
+}
+
+function isUsableMediaText(text = '') {
+  const value = String(text || '').trim()
+  return !!value && !isPlaceholderMediaName(value)
+}
+
+export function normalizeAssetPath(path = '') {
+  const value = String(path || '').trim()
+  if (!value) return ''
+  const cleaned = value.split('#')[0].split('?')[0]
+  const repoPath = cleaned.match(/\/(?:content|assets)\/.*$/)
+  return repoPath ? repoPath[0] : cleaned
+}
+
+export function fallbackMediaText(path = '') {
+  const normalizedPath = normalizeAssetPath(path)
+  const name = normalizedPath.split('/').pop() || ''
+  const fileName = name.replace(/\.[^.]+$/, '').trim()
+  if (isPlaceholderMediaName(fileName)) return ''
+  return fileName.replace(/[-_]+/g, ' ').trim()
+}
+
+export function findMediaText(node) {
+  if (!node || typeof node !== 'object') return ''
+  for (const key of mediaTextKeys) {
+    const value = node[key]
+    if (typeof value === 'string' && isUsableMediaText(value)) {
+      return value.trim()
+    }
+  }
+  for (const value of Object.values(node)) {
+    const text = findMediaText(value)
+    if (text) return text
+  }
+  return ''
+}
+
+export function findNodeFromPath(nodes, path) {
+  if (!nodes || !path) return null
+  if (Array.isArray(nodes)) {
+    for (const node of nodes) {
+      const found = findNodeFromPath(node, path)
+      if (found) return found
+    }
+    return null
+  }
+  if (typeof nodes !== 'object') return null
+  if (nodes.path === path) return nodes
+  if (nodes.children) return findNodeFromPath(nodes.children, path)
+  for (const value of Object.values(nodes)) {
+    if (value && typeof value === 'object') {
+      const found = findNodeFromPath(value, path)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+export async function resolveMediaText(path = '', nodes = null, cache = mediaTextCache) {
+  const normalizedPath = normalizeAssetPath(path)
+  if (!normalizedPath) return ''
+
+  const cached = cache && cache.get(normalizedPath)
+  if (cached) return cached
+
+  try {
+    const response = await fetch(`${normalizedPath}.1.json`)
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const data = await response.json()
+    const text = findMediaText(data)
+    if (text) {
+      if (cache) cache.set(normalizedPath, text)
+      return text
+    }
+  } catch (e) {
+    // Fall through to the browser tree and filename fallback below.
+  }
+
+  const node = findNodeFromPath(nodes, normalizedPath)
+  if (node) {
+    const text = findMediaText(node)
+    if (text) {
+      if (cache) cache.set(normalizedPath, text)
+      return text
+    }
+  }
+
+  return fallbackMediaText(normalizedPath)
+}

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/js/mediaText.js
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/js/mediaText.js
@@ -37,6 +37,10 @@ function isUsableMediaText(text = '') {
   return !!value && !isPlaceholderMediaName(value)
 }
 
+export function isImagePath(path = '') {
+  return /\.(jpg|jpeg|png|gif|svg|webp|avif)$/i.test(String(path || ''))
+}
+
 export function normalizeAssetPath(path = '') {
   const value = String(path || '').trim()
   if (!value) return ''

--- a/buildscripts/buildvue.js
+++ b/buildscripts/buildvue.js
@@ -4,10 +4,9 @@ const fs        = require('fs-extra')
 const rollup    = require( 'rollup' )
 const path      = require('path')
 const vue       = require('rollup-plugin-vue')
-const babel     = require('@rollup/plugin-babel').babel
+const buble     = require('rollup-plugin-buble')
 const commonjs  = require('rollup-plugin-commonjs')
 const camelcase = require('camelcase')
-const presetEnv = require('@babel/preset-env')
 
 console.log('========== building vue files ==========')
 
@@ -68,13 +67,7 @@ function compileComponent(file){
         compileTemplate: true,
         css: `${distBasePath}/css/${nameCamelCase}.css`
       }),
-      babel({
-        babelHelpers: 'bundled',
-        babelrc: false,
-        configFile: false,
-        presets: [[presetEnv, {modules: false, targets: {ie: '11'}}]],
-        exclude: 'node_modules/**'
-      }),
+      buble(),
       commonjs()
     ]
   }).then( function(bundle) {

--- a/buildscripts/buildvue.js
+++ b/buildscripts/buildvue.js
@@ -4,9 +4,10 @@ const fs        = require('fs-extra')
 const rollup    = require( 'rollup' )
 const path      = require('path')
 const vue       = require('rollup-plugin-vue')
-const buble     = require('rollup-plugin-buble')
+const babel     = require('@rollup/plugin-babel').babel
 const commonjs  = require('rollup-plugin-commonjs')
 const camelcase = require('camelcase')
+const presetEnv = require('@babel/preset-env')
 
 console.log('========== building vue files ==========')
 
@@ -67,7 +68,13 @@ function compileComponent(file){
         compileTemplate: true,
         css: `${distBasePath}/css/${nameCamelCase}.css`
       }),
-      buble(),
+      babel({
+        babelHelpers: 'bundled',
+        babelrc: false,
+        configFile: false,
+        presets: [[presetEnv, {modules: false, targets: {ie: '11'}}]],
+        exclude: 'node_modules/**'
+      }),
       commonjs()
     ]
   }).then( function(bundle) {
@@ -199,5 +206,3 @@ for(let i = 0; i < vueFiles.length; i++) {
 }
 
 fs.writeFileSync(timestampTokenFile, `${Date.now()}`, 'utf-8');
-
-

--- a/buildscripts/package-lock.json
+++ b/buildscripts/package-lock.json
@@ -1618,7 +1618,7 @@
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA=="
     },
     "json-schema": {
       "version": "0.4.0",

--- a/samples/example-vue-site/ui.apps/src/main/content/jcr_root/apps/example/components/image/.content.xml
+++ b/samples/example-vue-site/ui.apps/src/main/content/jcr_root/apps/example/components/image/.content.xml
@@ -29,4 +29,5 @@
           sling:resourceSuperType="pagerendervue/components/base"
           jcr:title="Image"
           group="Content"
+          alt=""
           />

--- a/samples/example-vue-site/ui.apps/src/main/content/jcr_root/apps/example/components/image/dialog.json
+++ b/samples/example-vue-site/ui.apps/src/main/content/jcr_root/apps/example/components/image/dialog.json
@@ -9,6 +9,13 @@
           "model": "imagePath",
           "browserRoot": "/content/example/assets",
           "placeholder": "select path"
+        },
+        {
+          "type": "input",
+          "inputType": "text",
+          "label": "alt",
+          "model": "alt",
+          "placeholder": "enter alt text"
         }
       ]
     },

--- a/samples/example-vue-site/ui.apps/src/main/content/jcr_root/apps/example/components/image/template.vue
+++ b/samples/example-vue-site/ui.apps/src/main/content/jcr_root/apps/example/components/image/template.vue
@@ -24,7 +24,7 @@
   -->
 <template>
     <div v-bind:data-per-path="model.path">
-        <img  v-bind:src="image" v-bind:alt="model.caption" style="max;width: 100%;">
+        <img  v-bind:src="image" v-bind:alt="model.alt || model.caption || ''" style="max-width: 100%;">
     </div>
 </template>
 

--- a/themes/themeclean/core/src/main/java/com/themeclean/models/SpacerModel.java
+++ b/themes/themeclean/core/src/main/java/com/themeclean/models/SpacerModel.java
@@ -210,6 +210,11 @@ public class SpacerModel extends AbstractComponent {
 	@Inject
 	private String bgimage;
 
+	/* {"type":"string","x-source":"inject","x-form-label":"Background Image Alt Text","x-form-type":"text","x-form-visible":"model.backgroundtype == 'image' and model.custombackground == 'true'"} */
+	@Inject
+	@Default(values ="")
+	private String bgimagealttext;
+
 	/* {"type":"string","x-source":"inject","x-form-label":"Overlay","x-form-type":"materialswitch","x-form-visible":"model.backgroundtype == 'image' and model.custombackground == 'true'"} */
 	@Inject
 	private String overlay;
@@ -271,6 +276,11 @@ public class SpacerModel extends AbstractComponent {
 	/* {"type":"string","x-source":"inject","x-form-label":"Background Image","x-form-type":"pathbrowser","x-form-visible":"model.backgroundtype == 'image' and model.custombackground == 'true'","x-form-browserRoot":"/content/themeclean/assets"} */
 	public String getBgimage() {
 		return bgimage;
+	}
+
+	/* {"type":"string","x-source":"inject","x-form-label":"Background Image Alt Text","x-form-type":"text","x-form-visible":"model.backgroundtype == 'image' and model.custombackground == 'true'"} */
+	public String getBgimagealttext() {
+		return bgimagealttext;
 	}
 
 	/* {"type":"string","x-source":"inject","x-form-label":"Overlay","x-form-type":"materialswitch","x-form-visible":"model.backgroundtype == 'image' and model.custombackground == 'true'"} */

--- a/themes/themeclean/fragments/cards/model.json
+++ b/themes/themeclean/fragments/cards/model.json
@@ -69,13 +69,15 @@
               "x-source": "inject",
               "x-form-label": "Card Image",
               "x-form-type": "pathbrowser",
-              "x-form-browserRoot": "/content/themeclean/assets"
+              "x-form-browserRoot": "/content/themeclean/assets",
+              "x-form-alt-source": "asset"
             },
             "imagealttext": {
 	          "type": "string",
 	          "x-source": "inject",
 	          "x-form-label": "Image Alt Text",
-	          "x-form-type": "text"
+	          "x-form-type": "text",
+	          "x-form-default-from": "image"
 	        },
             "buttontext": {
               "type": "string",

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/accordion/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/accordion/dialog.json
@@ -101,6 +101,7 @@
       "placeholder": "imagesrc",
       "label": "Image Source",
       "model": "imagesrc",
+      "defaultAltFromAsset": true,
       "visible": "model.mediatype == 'image' and model.showmedia == 'true'"
     },
     {
@@ -109,6 +110,7 @@
       "placeholder": "imagealttext",
       "label": "Image Alt Text",
       "model": "imagealttext",
+      "defaultFrom": "imagesrc",
       "visible": "model.mediatype == 'image' and model.showmedia == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/accordion/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/accordion/dialog.json
@@ -251,6 +251,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articleheader/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articleheader/dialog.json
@@ -133,6 +133,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articlemediafull/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articlemediafull/dialog.json
@@ -56,6 +56,7 @@
       "placeholder": "imagesrc",
       "label": "Image Source",
       "model": "imagesrc",
+      "defaultAltFromAsset": true,
       "visible": "model.mediatype == 'image'"
     },
     {
@@ -64,6 +65,7 @@
       "placeholder": "mediaalttext",
       "label": "Media Alt Text",
       "model": "mediaalttext",
+      "defaultFrom": "imagesrc",
       "visible": "model.mediatype == 'image'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articlemediafull/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articlemediafull/dialog.json
@@ -160,6 +160,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articlepager/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articlepager/dialog.json
@@ -90,6 +90,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articlequote/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articlequote/dialog.json
@@ -102,6 +102,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletabs/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletabs/dialog.json
@@ -143,6 +143,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletextblock/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletextblock/dialog.json
@@ -83,6 +83,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletextmedia/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletextmedia/dialog.json
@@ -183,6 +183,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletextmedia/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletextmedia/dialog.json
@@ -79,6 +79,7 @@
       "placeholder": "imagesrc",
       "label": "Image Source",
       "model": "imagesrc",
+      "defaultAltFromAsset": true,
       "visible": "model.mediatype == 'image'"
     },
     {
@@ -87,6 +88,7 @@
       "placeholder": "mediaalttext",
       "label": "Media Alt Text",
       "model": "mediaalttext",
+      "defaultFrom": "imagesrc",
       "visible": "model.mediatype == 'image'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletwocolumn/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/articletwocolumn/dialog.json
@@ -93,6 +93,16 @@
           "placeholder": "bgimage",
           "label": "Background Image",
           "model": "bgimage",
+          "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+          "defaultAltFromAsset": true
+        },
+        {
+          "type": "input",
+          "inputType": "text",
+          "placeholder": "bgimagealttext",
+          "label": "Background Image Alt Text",
+          "model": "bgimagealttext",
+          "defaultFrom": "bgimage",
           "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
         },
         {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/block/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/block/dialog.json
@@ -76,6 +76,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/breadcrumb/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/breadcrumb/dialog.json
@@ -83,6 +83,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/cards/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/cards/dialog.json
@@ -88,14 +88,16 @@
           "browserRoot": "/content/themeclean/assets",
           "placeholder": "image",
           "label": "Card Image",
-          "model": "image"
+          "model": "image",
+          "defaultAltFromAsset": true
         },
         {
           "type": "input",
           "inputType": "text",
           "placeholder": "imagealttext",
           "label": "Image Alt Text",
-          "model": "imagealttext"
+          "model": "imagealttext",
+          "defaultFrom": "image"
         },
         {
           "type": "input",

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/cards/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/cards/dialog.json
@@ -256,6 +256,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/carousel/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/carousel/dialog.json
@@ -207,6 +207,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/carousel/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/carousel/dialog.json
@@ -101,7 +101,8 @@
           "browserRoot": "/content/themeclean/assets",
           "placeholder": "imagepath",
           "label": "Image Source",
-          "model": "imagepath"
+          "model": "imagepath",
+          "defaultAltFromAsset": true
         },
         {
           "type": "input",
@@ -122,7 +123,8 @@
           "inputType": "text",
           "placeholder": "alt",
           "label": "Image Alt Text",
-          "model": "alt"
+          "model": "alt",
+          "defaultFrom": "imagepath"
         }
       ],
       "placeholder": "slides",

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/footer/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/footer/dialog.json
@@ -16,6 +16,7 @@
       "placeholder": "logo",
       "label": "Logo",
       "model": "logo",
+      "defaultAltFromAsset": true,
       "visible": "model.showlogo == 'true'"
     },
     {
@@ -24,6 +25,7 @@
       "placeholder": "logoalttext",
       "label": "Logo Alt Text",
       "model": "logoalttext",
+      "defaultFrom": "logo",
       "visible": "model.showlogo == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/footer/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/footer/dialog.json
@@ -214,6 +214,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/header/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/header/dialog.json
@@ -249,6 +249,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/header/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/header/dialog.json
@@ -5,14 +5,16 @@
       "browserRoot": "/content/themeclean/assets",
       "placeholder": "logo",
       "label": "Logo",
-      "model": "logo"
+      "model": "logo",
+      "defaultAltFromAsset": true
     },
     {
       "type": "input",
       "inputType": "text",
       "placeholder": "logoalttext",
       "label": "Logo Alt Text",
-      "model": "logoalttext"
+      "model": "logoalttext",
+      "defaultFrom": "logo"
     },
     {
       "type": "pathbrowser",

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/mediablock/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/mediablock/dialog.json
@@ -57,6 +57,7 @@
       "placeholder": "imagesrc",
       "label": "Image Source",
       "model": "imagesrc",
+      "defaultAltFromAsset": true,
       "visible": "model.mediatype == 'image'"
     },
     {
@@ -65,6 +66,7 @@
       "placeholder": "mediaalttext",
       "label": "Media Alt Text",
       "model": "mediaalttext",
+      "defaultFrom": "imagesrc",
       "visible": "model.mediatype == 'image'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/mediablock/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/mediablock/dialog.json
@@ -161,6 +161,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/spacer/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/spacer/dialog.json
@@ -84,6 +84,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/tabs/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/tabs/dialog.json
@@ -121,6 +121,7 @@
       "placeholder": "imagesrc",
       "label": "Image Source",
       "model": "imagesrc",
+      "defaultAltFromAsset": true,
       "visible": "model.mediatype == 'image' and model.showmedia == 'true'"
     },
     {
@@ -129,6 +130,7 @@
       "placeholder": "imagealttext",
       "label": "Image Alt Text",
       "model": "imagealttext",
+      "defaultFrom": "imagesrc",
       "visible": "model.mediatype == 'image' and model.showmedia == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/tabs/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/tabs/dialog.json
@@ -293,6 +293,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/teaserhorizontal/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/teaserhorizontal/dialog.json
@@ -286,6 +286,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {

--- a/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/teaservertical/dialog.json
+++ b/themes/themeclean/ui.apps/src/main/content/jcr_root/apps/themeclean/components/teaservertical/dialog.json
@@ -289,6 +289,16 @@
       "placeholder": "bgimage",
       "label": "Background Image",
       "model": "bgimage",
+      "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'",
+      "defaultAltFromAsset": true
+    },
+    {
+      "type": "input",
+      "inputType": "text",
+      "placeholder": "bgimagealttext",
+      "label": "Background Image Alt Text",
+      "model": "bgimagealttext",
+      "defaultFrom": "bgimage",
       "visible": "model.backgroundtype == 'image' and model.custombackground == 'true'"
     },
     {


### PR DESCRIPTION
Needs the changes from [stkd-theme #639](https://github.com/swiss-taekwondo/stkd-theme/pull/639)

## What changed

### Default Alt Text for Images
- Images now have a field "Alt Text" that is used as the default alt text for the image.

### Shared media text resolution
- Added a shared resolver in `peregrine-cms/admin-base/ui.apps/src/main/content/jcr_root/apps/js/mediaText.js`.
- Centralized the media text key lookup in one place.
- Added filename fallback filtering so placeholder-like names are ignored:
  - numeric IDs
  - UUIDs
  - `image-1` / `media_123` style names
  - WhatsApp export names
  - `img*` / `dcim*` style names
  - social export names like `642758143_..._n.jpeg`

### Shared path browser behavior
- The shared image picker now seeds blank companion fields from asset metadata when an image is selected.
- It also clears inherited default text on replace/delete when the current value still matches the previous image’s default text or filename-derived fallback.

## Affected Components with image or background image fields
- `breadcrumb`
- `cards`
- `carousel`
- `containerblock`
- `datalist`
- `footer`
- `header`
- `maps`
- `media`
- `pagelist`
- `pager`
- `reference`
- `richtext`
- `separator`
- `spacer`
- `teaserhorizontal`
- `teaservertical`
- `text`