### PR TITLE
Purify rte

### DIFF
--- a/admin-base/ui.apps/package-lock.json
+++ b/admin-base/ui.apps/package-lock.json
@@ -1254,7 +1254,9 @@
       }
     },
     "@driftingsands/stkd-axios-override": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@driftingsands/stkd-axios-override/-/stkd-axios-override-1.2.0.tgz",
+      "integrity": "sha512-Zv6eVXO/pHQ5ELtT9zM+03aVAB735KZheaXmtmyxdgRda2FQx+ZAEwcSR0U5L/CLqEE02qEXKxBGFdWOM09wbw=="
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.12",
@@ -1351,6 +1353,12 @@
       "version": "11.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.10.tgz",
       "integrity": "sha512-leUNzbFTMX94TWaIKz8N15Chu55F9QSH+INKayQr5xpkasBQBRF3qQXfo3/dOnMU/dEIit+Y/SU8HyOjq++GwA=="
+    },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
     },
     "@vue/compiler-sfc": {
       "version": "2.7.16",
@@ -2359,6 +2367,14 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "requires": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "dot-prop": {

--- a/admin-base/ui.apps/package.json
+++ b/admin-base/ui.apps/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@driftingsands/stkd-axios-override": "^1.2.0",
     "codemirror-formatting": "^1.0.0",
+    "dompurify": "^3.4.12",
     "drag-drop-touch": "^1.3.0",
     "expr-eval": "^1.2.2",
     "font-awesome": "^4.7.0",

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -2688,29 +2688,29 @@ export default {
         const sel = window.getSelection()
         const range = this._savedRange
 
-          const styles = []
-          if (this.browser.img.width) styles.push(`width: ${this.browser.img.width}px`)
-          if (this.browser.img.height) styles.push(`height: ${this.browser.img.height}px`)
-          if (this.browser.img.objectFit) styles.push(`object-fit: ${this.browser.img.objectFit}`)
-          const mediaText = this.browser.linkTitle || this.browser.altText || await this.getDefaultMediaText(this.browser.path.selected)
+        const styles = []
+        if (this.browser.img.width) styles.push(`width: ${this.browser.img.width}px`)
+        if (this.browser.img.height) styles.push(`height: ${this.browser.img.height}px`)
+        if (this.browser.img.objectFit) styles.push(`object-fit: ${this.browser.img.objectFit}`)
+        const mediaText = this.browser.linkTitle || this.browser.altText || await this.getDefaultMediaText(this.browser.path.selected)
 
-          const img = document.createElement('img')
-          img.setAttribute('src', this.browser.path.selected)
-          img.setAttribute('alt', mediaText || '')
-          img.setAttribute('title', mediaText || '')
-          if (styles.length) {
-            img.setAttribute('style', styles.join(';'))
-          }
+        const img = document.createElement('img')
+        img.setAttribute('src', this.browser.path.selected)
+        img.setAttribute('alt', mediaText || '')
+        img.setAttribute('title', mediaText || '')
+        if (styles.length) {
+          img.setAttribute('style', styles.join(';'))
+        }
 
-          range.deleteContents()
-          range.insertNode(img)
-          range.setStartAfter(img)
-          range.collapse(true)
-          sel.removeAllRanges()
-          sel.addRange(range)
+        range.deleteContents()
+        range.insertNode(img)
+        range.setStartAfter(img)
+        range.collapse(true)
+        sel.removeAllRanges()
+        sel.addRange(range)
 
-          const editor = this.getEditorFrom(range)
-          if (editor) editor.dispatchEvent(new Event('input'))
+        const editor = this.getEditorFrom(range)
+        if (editor) editor.dispatchEvent(new Event('input'))
 
       }
       this.browser.mediaSourcePath = ''

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -2528,6 +2528,10 @@ export default {
       const typeLC = this.browser.type?.toLowerCase()
       const isAssetOrFile = typeLC === PathBrowser.Type.ASSET || typeLC === 'file'
       let href = this.browser.path.selected || ''
+      if (!href) {
+        console.warn('no href specified in onLinkSelect')
+        return
+      }
 
       const isPageType = this.browser.type?.toLowerCase() === PathBrowser.Type.PAGE
       if (href.startsWith('/') && isPageType && !href.includes('.html')) {
@@ -2584,19 +2588,13 @@ export default {
           }
         }
 
-        link.appendChild(range.extractContents())
+        link.append(range.extractContents())
         if (link.textContent.trim().length < 1 && link.children.length === 0) {
           link.textContent = href
         }
         range.insertNode(link)
         this._savedRange = null
-        if ($perAdminApp.getNodeFromViewOrNull('/state/contentview/editor/active')) {
-          $perAdminApp.action(this, 'reWrapEditable')
-        }
-        $perAdminApp.action(this, 'writeInlineToModel')
-        this.$nextTick(() => {
-          $perAdminApp.action(this, 'textEditorWriteToModel')
-        })
+        textEditor.dispatchEvent(new Event('input'))
       } else {
         let anchor = this.param.anchor
         if (!anchor || !anchor.parentNode) {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/richtoolbar/template.vue
@@ -2337,7 +2337,7 @@ export default {
 
       const savedSel = saveSelection(container, doc) || $perAdminApp.getNodeFromViewOrNull('/state/inline/lastSelectionBuffer')
       this.selection.buffer = savedSel
-      this.selection.restore = !!savedSel
+      this.selection.restore = false
       this.startBrowsing()
     },
 
@@ -2528,8 +2528,16 @@ export default {
       const typeLC = this.browser.type?.toLowerCase()
       const isAssetOrFile = typeLC === PathBrowser.Type.ASSET || typeLC === 'file'
       let href = this.browser.path.selected || ''
-      if (!href) {
+      if (!href.trim()) {
         console.warn('no href specified in onLinkSelect')
+        $perAdminApp.toast("Invalid link", "warn", 3000)
+        return
+      }
+      try {
+        new URL(href, window.location.origin)
+      } catch (e) {
+        console.warn('invalid href specified in onLinkSelect', href, e)
+        $perAdminApp.toast("Invalid link", "warn", 3000)
         return
       }
 
@@ -2676,19 +2684,17 @@ export default {
         this.browser.mediaSourceText = ''
         this.browser.mediaSourceFallback = ''
       } else {
-        const doc = this.selection.doc || this.getInlineDoc() || document
-        const win = doc.defaultView || window
-        const sel = win.getSelection ? win.getSelection() : window.getSelection()
+        // insertImage
+        const sel = window.getSelection()
+        const range = this._savedRange
 
-        if (sel && sel.rangeCount > 0) {
-          const range = sel.getRangeAt(0)
           const styles = []
           if (this.browser.img.width) styles.push(`width: ${this.browser.img.width}px`)
           if (this.browser.img.height) styles.push(`height: ${this.browser.img.height}px`)
           if (this.browser.img.objectFit) styles.push(`object-fit: ${this.browser.img.objectFit}`)
           const mediaText = this.browser.linkTitle || this.browser.altText || await this.getDefaultMediaText(this.browser.path.selected)
 
-          const img = doc.createElement('img')
+          const img = document.createElement('img')
           img.setAttribute('src', this.browser.path.selected)
           img.setAttribute('alt', mediaText || '')
           img.setAttribute('title', mediaText || '')
@@ -2705,7 +2711,6 @@ export default {
 
           const editor = this.getEditorFrom(range)
           if (editor) editor.dispatchEvent(new Event('input'))
-        }
 
       }
       this.browser.mediaSourcePath = ''

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
@@ -54,59 +54,7 @@
 import {Key} from '../../../../../js/constants'
 import {restoreSelection, saveSelection, set} from '../../../../../js/utils'
 import Richtoolbar from '../../admin/components/richtoolbar/template.vue'
-
-const allowedClassesMap = {
-  'peregrine-icon': true,
-}
-const allowedStylesMap = {
-  // bold, italic, etc handled by html tags
-  "text-align": true,
-  "font-size": true,
-  'width':true,
-  'height':true,
-};
-const allowedStylesElementsMap = {
-  IMG: true,
-}
-function cleanupRteContent(tempDiv) {
-  tempDiv.querySelectorAll('[style]').forEach((span) => {
-    if (allowedStylesElementsMap[span.nodeName]) return;
-    const propertiesToRemove = []
-    for (let i = 0; i < span.style.length; i++) {
-      const property = span.style.item(i);
-      if (!allowedStylesMap[property]) {
-        propertiesToRemove.push(property);
-      }
-    }
-    // must be done in later step, otherwise length changes
-    for (let i = 0; i < propertiesToRemove.length; i++) {
-      span.style.removeProperty(propertiesToRemove[i]);
-    }
-  })
-
-  tempDiv.querySelectorAll('[class]').forEach((el) => {
-    const newClassName = Array.from(el.classList).filter((cls) => allowedClassesMap[cls]).join(' ')
-    el.className = newClassName;
-  })
-
-  tempDiv.querySelectorAll('[data-per-inline]').forEach((el) => {
-    el.removeAttribute('data-per-inline')
-  })
-  tempDiv.querySelectorAll('[contenteditable]').forEach((el) => {
-    el.removeAttribute('contenteditable')
-  })
-
-  tempDiv.querySelectorAll('[id]').forEach((el) => {
-    el.removeAttribute('id')
-  })
-
-  // remove empty anchor tags, sometimes appearing when adding & removing lists
-  tempDiv.querySelectorAll('a:empty').forEach((el) => {
-    el.remove()
-  })
-
-  return tempDiv
-}
+import DOMPurify from 'dompurify'
 
 function getAnchorFromSelection(selection) {
   const anchorNode = selection && selection.rangeCount > 0 ? selection.anchorNode : null
@@ -132,6 +80,66 @@ function resolveHeadingShortcutDigit(event) {
   }
 
   return null
+}
+
+const allowedClasses = [
+	'peregrine-icon',
+];
+const allowedStyles = [
+	'text-align',
+	'font-size',
+	'width',
+	'height',
+	'vertical-align',
+	'display',
+];
+DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
+ if (data.attrName === 'class') {
+    const filtered = data.attrValue
+      .split(/\s+/)
+      .filter(cls => allowedClasses.includes(cls))
+      .join(' ');
+
+    if (filtered) {
+      data.attrValue = filtered;
+    } else {
+      data.keepAttr = false;
+    }
+  }
+
+  if (data.attrName === 'style') {
+    const declarations = data.attrValue
+      .split(';')
+      .map(s => s.trim())
+      .filter(Boolean);
+
+    const filtered = [];
+
+    for (const decl of declarations) {
+      const idx = decl.indexOf(':');
+      if (idx === -1) continue;
+
+      const property = decl.slice(0, idx).trim().toLowerCase();
+      const value = decl.slice(idx + 1).trim();
+
+      if (allowedStyles.includes(property)) {
+        filtered.push(`${property}: ${value}`);
+      }
+    }
+
+    if (filtered.length) {
+      data.attrValue = filtered.join('; ');
+    } else {
+      data.keepAttr = false;
+    }
+  }
+})
+const domPurifyConfig = {
+	ALLOWED_TAGS: [
+		'p', 'span', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'br',
+		'strong', 'em', 'b', 'i', 'u', 'a', 'img',
+		'ul', 'ol', 'li', 'sub', 'sup'
+	],
 }
 
 export default {
@@ -337,12 +345,14 @@ export default {
     value() {
       if (!this.value) return
       const textCheckDiv = document.createElement('div')
-      textCheckDiv.innerHTML = this.value
+      textCheckDiv.innerHTML = DOMPurify.sanitize(this.value, domPurifyConfig)
+      textCheckDiv.querySelectorAll('a:empty').forEach((el) => {
+        el.remove()
+      })
       // removing all text usually results in the left over elements like empty <p> tags or a <br> tags.
       // make sure to treat this as empty but if images and lists are present, treat it as non-empty.
       // as a side effect, this requires text to exist before being able to set Headings, super/sub-script.
       if (!textCheckDiv.textContent.trim() && !textCheckDiv.querySelector('img, ul, ol')) this.value = '';
-      cleanupRteContent(textCheckDiv)
       this.value = textCheckDiv.innerHTML
     }
   }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
@@ -346,8 +346,12 @@ export default {
       if (!this.value) return
       const textCheckDiv = document.createElement('div')
       textCheckDiv.innerHTML = DOMPurify.sanitize(this.value, domPurifyConfig)
-      textCheckDiv.querySelectorAll('a:empty').forEach((el) => {
-        el.remove()
+      // Replace links with no href or only whitespace with their content
+      textCheckDiv.querySelectorAll('a').forEach((el) => {
+        if (!el.getAttribute('href') || (!el.textContent.trim() && !el.querySelector('img'))) {
+          console.log("replacing invalid link with it's content:", el)
+          el.replaceWith(...el.childNodes)
+        }
       })
       // removing all text usually results in the left over elements like empty <p> tags or a <br> tags.
       // make sure to treat this as empty but if images and lists are present, treat it as non-empty.

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/texteditor/template.vue
@@ -140,6 +140,9 @@ const domPurifyConfig = {
 		'strong', 'em', 'b', 'i', 'u', 'a', 'img',
 		'ul', 'ol', 'li', 'sub', 'sup'
 	],
+	ADD_ATTR: [
+		'target'
+	]
 }
 
 export default {

--- a/admin-base/ui.apps/src/main/content/jcr_root/etc/felibs/admin/dependencies/node_modules.txt
+++ b/admin-base/ui.apps/src/main/content/jcr_root/etc/felibs/admin/dependencies/node_modules.txt
@@ -15,3 +15,4 @@ drag-drop-touch/DragDropTouch.js
 expr-eval/dist/bundle.min.js
 vue-codemirror-lite/dist/vuecodemirror.min.js
 ionicons/css/ionicons.min.css
+dompurify/dist/purify.min.js


### PR DESCRIPTION
Replacing old style & class filtering of RTE input with DomPurify. Only allowing a specific list of elements, classes and inline styles.

Fixed allowing blank href links to be added (clicking select in modal without choosing a path)

Link insertion is saved via triggered input event now. This fixes a case where link was removed 1 frame after being inserted during cypress tests.

RTE tests were updated along side this: https://github.com/swiss-taekwondo/stkd-peregrine-tests/commit/17a6494cddb7b2488cae321832c4fe9fcaf6dc7a They should be less flaky and now also tests `download` link attr