### PR TITLE
add support for inline CSS rendering in PageModel

### DIFF
--- a/pagerenderer/react/ui.apps/src/main/content/jcr_root/apps/pagerender/react/structure/page/page.html
+++ b/pagerenderer/react/ui.apps/src/main/content/jcr_root/apps/pagerender/react/structure/page/page.html
@@ -36,8 +36,8 @@
 </script>
 
 
-<sly data-sly-include=serviceworker.html"></sly>
-<sly data-sly-include=tracker-bodyend.html"></sly>
+<sly data-sly-include="serviceworker.html"></sly>
+<sly data-sly-include="tracker-bodyend.html"></sly>
 </body>
 </html>
 

--- a/pagerenderer/vue/core/src/main/java/com/peregrine/pagerender/vue/models/PageModel.java
+++ b/pagerenderer/vue/core/src/main/java/com/peregrine/pagerender/vue/models/PageModel.java
@@ -13,9 +13,9 @@ package com.peregrine.pagerender.vue.models;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,6 +41,9 @@ import java.util.List;
 import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
@@ -51,6 +54,9 @@ import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.factory.ModelFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by rr on 12/2/2016.
@@ -64,7 +70,9 @@ import org.apache.sling.models.factory.ModelFactory;
     name = JACKSON,
     extensions = JSON)
 public class PageModel extends Container {
+    private static final Logger log = LoggerFactory.getLogger(PageModel.class);
 
+    public static final String INLINE_CSS = "inlineCSS";
     public static final String SITE_CSS = "siteCSS";
     public static final String PREFETCH_DNS = "prefetchDNS";
     public static final String DOMAINS = "domains";
@@ -157,6 +165,9 @@ public class PageModel extends Container {
     @Optional
     private Boolean noFollow = false;
 
+    @Inject
+    @Optional
+    private Boolean inlineCSS = false;
 
     public String getSiteRoot() {
         String path = getPagePath();
@@ -194,6 +205,57 @@ public class PageModel extends Container {
             }
         }
         return siteCSS;
+    }
+
+    public Boolean getInlineCSS() {
+        if (!inlineCSS) {
+            Boolean value = (Boolean) getInheritedProperty(INLINE_CSS);
+            if (value != null) return value;
+            if (getTemplate() != null) {
+                PageModel templatePageModel = getTemplatePageModel();
+                if (templatePageModel != null) {
+                    return templatePageModel.getInlineCSS();
+                }
+            }
+        }
+        return inlineCSS;
+    }
+
+    public List<String> getInlineSiteCSS() {
+        List<String> cssContents = new ArrayList<>();
+        String[] paths = getSiteCSS();
+
+        if (paths != null) {
+            for (String path : paths) {
+                try {
+                    // Try reading the physical file from the JCR first
+                    Resource resource = getResource().getResourceResolver().getResource(path + "/jcr:content");
+                    if (resource != null) {
+                        InputStream is = resource.adaptTo(InputStream.class);
+                        if (is != null) {
+                            cssContents.add(IOUtils.toString(is, StandardCharsets.UTF_8));
+                            continue; // Skip HTTP fetch if JCR file exists
+                        }
+                    }
+
+                    // Fallback: Fetch dynamic clientlib via HTTP request
+                    String domain = StringUtils.isNotBlank(getPrimaryDomain())
+                            ? getPrimaryDomain()
+                            : getFallbackDomain();
+
+                    java.net.URL url = new java.net.URL(domain + path);
+                    java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
+                    conn.setRequestMethod("GET");
+
+                    try (java.io.InputStream in = conn.getInputStream()) {
+                        cssContents.add(IOUtils.toString(in, StandardCharsets.UTF_8));
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to inline CSS for path: {}.", path, e);
+                }
+            }
+        }
+        return cssContents;
     }
 
     /**
@@ -323,7 +385,7 @@ public class PageModel extends Container {
             for(Resource tag: tags.getChildren()) {
                 String tagString = tag.getValueMap().get("value", String.class);
                 Resource tagResource = tag.getResourceResolver().getResource(tagString);
-                if (tagResource != null) { 
+                if (tagResource != null) {
                     answer.add(new Tag(tag));
                 }
             }
@@ -338,7 +400,7 @@ public class PageModel extends Container {
             for(Resource tag: tags.getChildren()) {
                 String tagString = tag.getValueMap().get("value", String.class);
                 Resource tagResource = tag.getResourceResolver().getResource(tagString);
-                if (tagResource != null) { 
+                if (tagResource != null) {
                     answer.add(new Tag(tag).getName());
                 }
             }

--- a/pagerenderer/vue/core/src/main/java/com/peregrine/pagerender/vue/models/PageModel.java
+++ b/pagerenderer/vue/core/src/main/java/com/peregrine/pagerender/vue/models/PageModel.java
@@ -263,9 +263,9 @@ public class PageModel extends Container {
                     }
 
                     // Fallback: Fetch dynamic clientlib via HTTP request
-                    String domain = StringUtils.isNotBlank(getPrimaryDomain())
-                            ? getPrimaryDomain()
-                            : getFallbackDomain();
+                    String domain = StringUtils.isNotBlank(getFallbackDomain())
+                            ? getFallbackDomain()
+                            : getPrimaryDomain();
 
                     java.net.URL url = new java.net.URL(domain + path);
                     java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();

--- a/pagerenderer/vue/core/src/main/java/com/peregrine/pagerender/vue/models/PageModel.java
+++ b/pagerenderer/vue/core/src/main/java/com/peregrine/pagerender/vue/models/PageModel.java
@@ -207,6 +207,29 @@ public class PageModel extends Container {
         return siteCSS;
     }
 
+    /**
+     * Minifies a CSS string by removing comments, line breaks, and extra spaces.
+     */
+    private String minifyCSS(String css) {
+        if (css == null) {
+            return "";
+        }
+
+        // 1. Remove multi-line comments: /* ... */
+        css = css.replaceAll("/\\*[\\s\\S]*?\\*/", "");
+
+        // 2. Replace line breaks and tabs with a single space
+        css = css.replaceAll("[\\n\\r\\t]", " ");
+
+        // 3. Replace multiple spaces with a single space
+        css = css.replaceAll("\\s+", " ");
+
+        // 4. Remove spaces around structural characters: { } : ; , >
+        css = css.replaceAll("\\s*([\\{\\}\\:\\;\\,\\>])\\s*", "$1");
+
+        return css.trim();
+    }
+
     public Boolean getInlineCSS() {
         if (!inlineCSS) {
             Boolean value = (Boolean) getInheritedProperty(INLINE_CSS);
@@ -233,7 +256,8 @@ public class PageModel extends Container {
                     if (resource != null) {
                         InputStream is = resource.adaptTo(InputStream.class);
                         if (is != null) {
-                            cssContents.add(IOUtils.toString(is, StandardCharsets.UTF_8));
+                            String rawCss = IOUtils.toString(is, StandardCharsets.UTF_8);
+                            cssContents.add(minifyCSS(rawCss));
                             continue; // Skip HTTP fetch if JCR file exists
                         }
                     }
@@ -248,7 +272,8 @@ public class PageModel extends Container {
                     conn.setRequestMethod("GET");
 
                     try (java.io.InputStream in = conn.getInputStream()) {
-                        cssContents.add(IOUtils.toString(in, StandardCharsets.UTF_8));
+                        String rawCss = IOUtils.toString(in, StandardCharsets.UTF_8);
+                        cssContents.add(minifyCSS(rawCss));
                     }
                 } catch (Exception e) {
                     log.error("Failed to inline CSS for path: {}.", path, e);

--- a/pagerenderer/vue/ui.apps/package-lock.json
+++ b/pagerenderer/vue/ui.apps/package-lock.json
@@ -10,7 +10,9 @@
       "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
     },
     "@driftingsands/stkd-axios-override": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@driftingsands/stkd-axios-override/-/stkd-axios-override-1.2.0.tgz",
+      "integrity": "sha512-Zv6eVXO/pHQ5ELtT9zM+03aVAB735KZheaXmtmyxdgRda2FQx+ZAEwcSR0U5L/CLqEE02qEXKxBGFdWOM09wbw=="
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
@@ -79,7 +79,7 @@
     $peregrineApp.registerView($perView)
     $peregrineApp.loadContentFrom("perPage", "${resource.parent.path @ context='unsafe'}.html", true)
 </script>
-<sly data-sly-include=serviceworker.html"></sly>
-<sly data-sly-include=tracker-bodyend.html"></sly>
+<sly data-sly-include="serviceworker.html"></sly>
+<sly data-sly-include="tracker-bodyend.html"></sly>
 </body>
 </html>

--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
@@ -5,7 +5,7 @@
 
     <sly data-sly-list="${helper.model.prefetchDNS}"><link rel="preconnect" href="${item}"><link rel="dns-prefetch" href="${item}"></sly>
     <sly data-sly-list="${helper.model.siteJS}"><link rel="preload" href="${item}" as="script"></sly>
-    <sly data-sly-list="${helper.model.siteCSS}"><link rel="preload" href="${item}" as="style"></sly>
+    <sly data-sly-list="${helper.model.siteCSS}" data-sly-test="${!helper.model.inlineCSS}"><link rel="preload" href="${item}" as="style"></sly>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#c0c0c0">
@@ -69,7 +69,18 @@
 
 <sly data-sly-include="renderer.html"></sly>
 
-<sly data-sly-list="${helper.model.siteCSS}"><link rel="stylesheet" href="${item}" type="text/css"></sly>
+<sly data-sly-test="${helper.model.inlineCSS}">
+    <style>
+        <sly data-sly-list="${helper.model.inlineSiteCSS}">
+            ${item @ context='unsafe'}
+        </sly>
+    </style>
+</sly>
+<sly data-sly-test="${!helper.model.inlineCSS}">
+    <sly data-sly-list="${helper.model.siteCSS}">
+        <link rel="stylesheet" href="${item}" type="text/css">
+    </sly>
+</sly>
 
 <script>
     var $perView = { view: 'preview' };

--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
@@ -69,17 +69,9 @@
 
 <sly data-sly-include="renderer.html"></sly>
 
-<sly data-sly-test="${helper.model.inlineCSS}">
-    <style>
-        <sly data-sly-list="${helper.model.inlineSiteCSS}">
-            ${item @ context='unsafe'}
-        </sly>
-    </style>
-</sly>
-<sly data-sly-test="${!helper.model.inlineCSS}">
-    <sly data-sly-list="${helper.model.siteCSS}">
-        <link rel="stylesheet" href="${item}" type="text/css">
-    </sly>
+<style data-sly-test="${helper.model.inlineCSS}"><sly data-sly-list="${helper.model.inlineSiteCSS}">${item @ context='unsafe'}</sly></style>
+<sly data-sly-test="${!helper.model.inlineCSS}" data-sly-list="${helper.model.siteCSS}">
+    <link rel="stylesheet" href="${item}" type="text/css">
 </sly>
 
 <script>


### PR DESCRIPTION
To test it, go to http://localhost:8080/bin/browser.html/content/stkd/templates/_jcr_content and add a new prop `inlineCSS` set to true. 

<img width="267" height="43" alt="Screenshot 2026-08-03 at 16 00 51" src="https://github.com/user-attachments/assets/33eb0d59-84ae-40e5-b6ac-afd734f9e132" />

You should then see the Site CSS inlined in <style>  if you visit a page like http://localhost:8080/content/stkd/pages/home.html :

<img width="548" height="518" alt="Screenshot 2026-08-03 at 16 01 14" src="https://github.com/user-attachments/assets/32938211-1264-4b93-8933-d6da122c389a" />
