### PR TITLE
Consistent Input Styling for Objects

### DIFF
--- a/admin-base/materialize/custom/_vue-form-generator.scss
+++ b/admin-base/materialize/custom/_vue-form-generator.scss
@@ -34,9 +34,6 @@
     margin: 0;
     box-sizing: border-box;
 
-    .collection {
-    }
-
     .field-wrap {
         margin: 5px 0px;
 
@@ -156,6 +153,7 @@
                 .wrapper {
                     position: relative;
                     input[type="color"]{
+                        cursor: pointer;
                         width: 100%;
                         height: 3rem;
                         padding: 0 5rem 0 0.15rem;
@@ -514,10 +512,10 @@
                         .lever {
                             margin-left: 0px;
                             // background-color: customColor("blue-grey", "lighten-3");
-                            &:after {
+                            // &:after {
                                 // background-color: customColor("blue-grey", "lighten-3");
                                 //box-shadow: none;
-                            }
+                            // }
                         }
                         input[type=checkbox]:checked {
                             + .lever {
@@ -669,11 +667,11 @@
                             &.deleted {
                                 display: none;
                             }
-                            &:first-child {
+                            // &:first-child {
                                 // .collapsible-header {
                                 //     border-top: 1px solid customColor("blue-grey", "lighten-4");
                                 // }
-                            }
+                            // }
                             &:last-child {
                                 .collapsible-body {
                                     border-bottom: none !important;
@@ -983,8 +981,13 @@
 }
 
 p.text-editor[readonly="readonly"],
-input:read-only:not([type="range"]),
-input:disabled:not([type="range"]) {
+input:read-only:not([type="range"]):not([type="color"]),
+input:disabled:not([type="range"]):not([type="color"]) {
     opacity: 0.5 !important;
     cursor: not-allowed !important;
+}
+
+input[type="color"]:read-only,
+input[type="color"]:disabled {
+    cursor: default;
 }

--- a/admin-base/materialize/custom/_vue-multiselect.scss
+++ b/admin-base/materialize/custom/_vue-multiselect.scss
@@ -65,6 +65,9 @@ fieldset[disabled] .multiselect {
   min-height: 40px;
   text-align: left;
   color: customColor("blue-grey", "darken-2");
+  border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
+  transition: border-top-color 0.15s ease-in-out, border-bottom-color 0.15s ease-in-out;
 }
 
 .multiselect * {
@@ -80,13 +83,18 @@ fieldset[disabled] .multiselect {
   opacity: 0.6;
 }
 
-.multiselect--active {
+.multiselect.multiselect--active:not(.multiselect--above) {
   z-index: 50;
+  border-top-color: #607d8b;
 }
 
-.multiselect--active .multiselect__current,
-.multiselect--active .multiselect__input,
-.multiselect--active .multiselect__tags {
+.multiselect--above.multiselect--active {
+  border-bottom-color: #607d8b;
+}
+
+.multiselect.multiselect--active .multiselect__current,
+.multiselect.multiselect--active .multiselect__input,
+.multiselect.multiselect--active .multiselect__tags {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
@@ -148,15 +156,21 @@ fieldset[disabled] .multiselect {
   padding: 0 40px 0 0.75rem;
   border: 1px solid customColor("blue-grey", "lighten-4");
   background: #fff;
+  height: 3rem;
 }
 
 .multiselect__tags input.multiselect__input {
   border-top: none;
   border-left: none;
   border-right: none;
-  border-bottom-color: transparent;
+  border-color: transparent !important;
+  box-shadow: none !important;
   padding-left: 0;
   width: 100%;
+  height: calc(3rem - 2px);
+  top: 0px;
+  bottom: 2px;
+  font-size: 14px;
 }
 
 .multiselect__tag {
@@ -238,9 +252,9 @@ fieldset[disabled] .multiselect {
 
 .multiselect__placeholder {
   color: #ADADAD;
-  display: inline-block;
-  margin-bottom: 10px;
-  padding-top: 2px;
+  display: flex;
+  align-items: center;
+  height: 100%;
 }
 
 .multiselect--active .multiselect__placeholder {
@@ -259,6 +273,9 @@ fieldset[disabled] .multiselect {
   -webkit-overflow-scrolling: touch;
   -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
+  transition:
+		border-color 0.15s ease-in-out,
+		box-shadow 0.15s ease-in-out;
 }
 
 .multiselect__content {
@@ -351,7 +368,6 @@ fieldset[disabled] .multiselect {
 .multiselect__option--selected.multiselect__option--highlight:after {
   content: attr(data-deselect);
   font-size: 20px;
-  // color: customColor("red", "base");
 }
 
 .multiselect--disabled {

--- a/admin-base/materialize/materialize-src/sass/components/forms/_input-fields.scss
+++ b/admin-base/materialize/materialize-src/sass/components/forms/_input-fields.scss
@@ -36,7 +36,6 @@ textarea.materialize-textarea {
   padding: $input-padding;
   box-shadow: none;
   box-sizing: content-box;
-  transition: $input-transition;
 
   // Disabled input style
   &:disabled,

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/pathbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/pathbrowser/template.vue
@@ -276,6 +276,7 @@ export default {
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+  padding: 1px;
 
   *  {
     width: 100% !important;
@@ -284,6 +285,9 @@ export default {
   }
   input {
     grid-area: 1 / 1 / 2 / 6;
+    transition:
+		border-color 0.15s ease-in-out,
+		box-shadow 0.15s ease-in-out;
   }
   .picker-open {
     grid-area: 1 / 6 / 2 / 7;

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -612,6 +612,12 @@ class PerAdminImpl {
                   }
                 }
 
+                if (field.inputType === 'color') {
+                    if (!field.default) {
+                        field.default = '#000000'
+                    }
+                }
+
                 if (field.type === 'collection') {
                   if (Array.isArray(field.fields)) {
                     for (let i = 0; i < field.fields.length; i++) {
@@ -701,21 +707,37 @@ class PerAdminImpl {
 
   populateObject(path, target, name, schema) {
     return this.populateComponentDefinitionFromNode(path)
-      .then(() => {
+      .then((componentName) => {
         return fetch('/admin/getObject.json' + path)
           .then(async (data) => {
             if (!schema) {
-              schema = await fetch('/admin/componentDefinition.json' + path).then((data) => data.model);
+              const componentDefs = $perAdminApp.getNodeFromView('/admin/componentDefinitions')
+              const cmpDef = componentDefs ? componentDefs[componentName] : null
+              schema = cmpDef ? cmpDef.model : null
             }
-            if (schema && schema.fields && schema.fields.forEach) schema.fields.forEach((field) => {
-              if (data[field.model] && field.multifield && field.serialized) {
-                try {
-                  data[field.model] = JSON.parse(data[field.model])
-                } catch(e) {
-                  data[field.model] = []
+            const applyDefaults = (fields) => {
+              if (!fields) return
+              fields.forEach((field) => {
+                if (data[field.model] && field.multifield && field.serialized) {
+                  try {
+                    data[field.model] = JSON.parse(data[field.model])
+                  } catch(e) {
+                    data[field.model] = []
+                  }
                 }
+                if (field.inputType === 'color' && !data[field.model]) {
+                  data[field.model] = field.default
+                }
+              })
+            }
+            if (schema) {
+              applyDefaults(schema.fields)
+              if (schema.groups) {
+                schema.groups.forEach((group) => {
+                  applyDefaults(group.fields)
+                })
               }
-            });
+            }
             if (data.tags) {
               data.tags = JSON.parse(data.tags)
             }

--- a/pagerenderer/vue/ui.apps/package-lock.json
+++ b/pagerenderer/vue/ui.apps/package-lock.json
@@ -10,7 +10,9 @@
       "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
     },
     "@driftingsands/stkd-axios-override": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@driftingsands/stkd-axios-override/-/stkd-axios-override-1.2.0.tgz",
+      "integrity": "sha512-Zv6eVXO/pHQ5ELtT9zM+03aVAB735KZheaXmtmyxdgRda2FQx+ZAEwcSR0U5L/CLqEE02qEXKxBGFdWOM09wbw=="
     },
     "@types/estree": {
       "version": "0.0.39",


### PR DESCRIPTION
Fixes [#701](https://github.com/swiss-taekwondo/stkd-theme/issues/701) and [#703](https://github.com/swiss-taekwondo/stkd-theme/issues/703)  

Before we had the default value `#000000`, the color picker looked like this:
<img width="420" height="96" alt="image" src="https://github.com/user-attachments/assets/0765f943-5017-4fe2-bda1-97690bcd3c16" />

Now it looks like this:
<img width="420" height="96" alt="image" src="https://github.com/user-attachments/assets/0063a62e-6fbc-48d7-816e-e97556f6aeae" />
Now, the white space is used and does not look so weird.
Every Object would need a Save to save the new default Value `#000000`.