### PR TITLE
When copying a Page, it will preselect the browserRoot

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -911,8 +911,10 @@ export default {
       this.checkActivationStatusAndPerform(() => {
         $perAdminApp.getApi().populateNodesForBrowser(this.path.current, 'pathBrowser')
             .then(() => {
+              this.path.selected = this.browserRoot
               this.isOpen = true;
             }).catch(() => {
+          this.path.selected = this.browserRoot
           $perAdminApp.getApi().populateNodesForBrowser(`/content/${site.tenant}`, 'pathBrowser');
         });
       });
@@ -921,8 +923,10 @@ export default {
     copyNode() {
       $perAdminApp.getApi().populateNodesForBrowser(this.path.current, 'pathBrowser')
           .then(() => {
+            this.path.selected = this.browserRoot
             this.isCopyOpen = true;
           }).catch(() => {
+        this.path.selected = this.browserRoot
         $perAdminApp.getApi().populateNodesForBrowser(`/content/${site.tenant}`, 'pathBrowser');
       });
 


### PR DESCRIPTION
It now selects browserRoot per Default.
Fixes [#724](https://github.com/swiss-taekwondo/stkd-theme/issues/724).