### PR TITLE
prevent link handling when link has no href

### DIFF
--- a/pagerenderer/vue/ui.apps/src/main/js/state.js
+++ b/pagerenderer/vue/ui.apps/src/main/js/state.js
@@ -54,6 +54,8 @@ window.onclick = function(ev) {
     var node = getClickable(ev.target)
 
     if(node) {
+        if (!node.getAttribute('href')) return false;
+
         var toUrl = node.href
         if (node.target === '_blank') {
             window.open(toUrl, '_blank', 'noopener,noreferrer')


### PR DESCRIPTION
Fixes: https://github.com/swiss-taekwondo/stkd-theme/issues/734

This can also be fixed in the theme by making the tablink handler call `stopPropagation()`, but I think this is the better overall solution. No reason to handle links without an href.